### PR TITLE
Lord#clean configuration (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 
 dist/
+
+.tt_backups/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1.0.2
+VERSION := v1.0.3
 
 .PHONY: build
 build:

--- a/coverage.html
+++ b/coverage.html
@@ -1,3 +1,5 @@
+<!-- File: coverage.html -->
+
 
 <!DOCTYPE html>
 <html>
@@ -55,7 +57,7 @@
 			<div id="nav">
 				<select id="files">
 				
-				<option value="file0">github.com/gourdian25/gourdiantoken/gourdiantoken.go (69.5%)</option>
+				<option value="file0">github.com/gourdian25/gourdiantoken/gourdiantoken.go (70.3%)</option>
 				
 				</select>
 			</div>
@@ -69,8 +71,13 @@
 		</div>
 		<div id="content">
 		
-		<pre class="file" id="file0" style="display: none">// gourdiantoken.go
+		<pre class="file" id="file0" style="display: none">// File: gourdiantoken.go
 
+// Package gourdiantoken provides a secure JWT token generation and validation system
+// with advanced features like token rotation, revocation, and configurable security policies.
+//
+// The package supports both symmetric (HMAC) and asymmetric (RSA/ECDSA) signing methods,
+// with built-in protections against common JWT vulnerabilities.
 package gourdiantoken
 
 import (
@@ -94,6 +101,23 @@ import (
         "github.com/redis/go-redis/v9"
 )
 
+const (
+        revokedAccessPrefix  = "revoked:access:"
+        revokedRefreshPrefix = "revoked:refresh:"
+        rotatedPrefix        = "rotated:"
+)
+
+// TokenType defines the type of token (access or refresh).
+//
+// Used to distinguish between short-lived access tokens and long-lived refresh tokens
+// in the token validation process.
+//
+// Example:
+//
+//        const myTokenType = AccessToken // or RefreshToken
+//
+// AccessToken represents a short-lived token used for API access
+// RefreshToken represents a long-lived token used to obtain new access tokens
 type TokenType string
 
 const (
@@ -101,6 +125,17 @@ const (
         RefreshToken TokenType = "refresh"
 )
 
+// SigningMethod defines the cryptographic method used for token signing.
+//
+// Determines whether symmetric (shared secret) or asymmetric (public/private key)
+// cryptography will be used.
+//
+// Example:
+//
+//        const method = Symmetric // or Asymmetric
+//
+// Symmetric indicates HMAC signing with a shared secret key
+// Asymmetric indicates signing with public/private key pairs (RSA/ECDSA)
 type SigningMethod string
 
 const (
@@ -108,99 +143,42 @@ const (
         Asymmetric SigningMethod = "asymmetric"
 )
 
-// GourdianTokenConfig defines the complete configuration needed to initialize the token system.
+// GourdianTokenConfig contains all configurable parameters for token generation and validation.
 //
-// This struct serves as the central configuration point for all token-related settings including:
-// - Cryptographic algorithm selection
-// - Key material paths or values
-// - Access and refresh token lifetimes
-// - Security features like rotation and revocation
-//
-// The configuration is designed to be explicit about security choices with safe defaults.
-// All durations are in Go's time.Duration format (e.g., 30*time.Minute).
-//
-// Security Recommendations:
-// - For production: Use asymmetric algorithms (RS256, ES256, EdDSA)
-// - Set reasonable token lifetimes (short for access, longer for refresh)
-// - Enable revocation for sensitive applications
+// This struct serves as the security policy definition for your token system,
+// allowing fine-grained control over token lifetimes, cryptographic methods,
+// and security features.
 //
 // Example Configuration:
 //
-//        cfg := GourdianTokenConfig{
-//            Algorithm: "RS256",
-//            SigningMethod: Asymmetric,
-//            PrivateKeyPath: "/path/to/private.pem",
-//            PublicKeyPath: "/path/to/public.pem",
-//            AccessToken: AccessTokenConfig{
-//                Duration: 15*time.Minute,
-//                RevocationEnabled: true,
-//            },
-//            RefreshToken: RefreshTokenConfig{
-//                Duration: 7*24*time.Hour,
-//                RotationEnabled: true,
-//            },
+//        config := GourdianTokenConfig{
+//            Algorithm:                "RS256",
+//            SigningMethod:            Asymmetric,
+//            PrivateKeyPath:           "/path/to/private.pem",
+//            PublicKeyPath:            "/path/to/public.pem",
+//            Issuer:                   "auth.example.com",
+//            AccessExpiryDuration:     30 * time.Minute,
+//            AccessMaxLifetimeExpiry:  24 * time.Hour,
+//            RefreshExpiryDuration:    7 * 24 * time.Hour,
+//            RefreshMaxLifetimeExpiry: 30 * 24 * time.Hour,
 //        }
 type GourdianTokenConfig struct {
-        Algorithm      string             // JWT signing algorithm (e.g., "HS256", "RS256"). Must match key type.
-        SigningMethod  SigningMethod      // Cryptographic method (Symmetric/Asymmetric)
-        SymmetricKey   string             // Base64-encoded secret key for HMAC (min 32 bytes for HS256)
-        PrivateKeyPath string             // Path to PEM-encoded private key file (asymmetric only)
-        PublicKeyPath  string             // Path to PEM-encoded public key/certificate (asymmetric only)
-        AccessToken    AccessTokenConfig  // Fine-grained access token settings
-        RefreshToken   RefreshTokenConfig // Fine-grained refresh token settings
-}
-
-// AccessTokenConfig contains settings specific to access token generation and validation.
-//
-// Access tokens are short-lived credentials that grant access to resources. These settings
-// control their security characteristics and validation requirements.
-//
-// Important Security Settings:
-// - Duration: Should be short (minutes to hours)
-// - MaxLifetime: Absolute maximum validity period
-// - RequiredClaims: Ensure essential claims are always validated
-//
-// Example:
-//
-//        AccessTokenConfig{
-//            Duration: 30*time.Minute,
-//            MaxLifetime: 24*time.Hour,
-//            RequiredClaims: []string{"jti", "sub", "exp"},
-//            RevocationEnabled: true,
-//        }
-type AccessTokenConfig struct {
-        Duration          time.Duration // Time until token expires after issuance (e.g., 30m)
-        MaxLifetime       time.Duration // Absolute maximum validity from creation (e.g., 24h)
-        Issuer            string        // Token issuer identifier (e.g., "auth.example.com")
-        Audience          []string      // Intended recipients (e.g., ["api.example.com"])
-        AllowedAlgorithms []string      // Whitelist of acceptable algorithms for verification
-        RequiredClaims    []string      // Mandatory claims that must be present and valid
-        RevocationEnabled bool          // Whether to check Redis for revoked tokens
-}
-
-// RefreshTokenConfig contains settings specific to refresh token generation and validation.
-//
-// Refresh tokens are long-lived credentials used to obtain new access tokens. These settings
-// control their extended lifetime and rotation behavior.
-//
-// Important Security Settings:
-// - RotationEnabled: Recommended for all production use
-// - ReuseInterval: Should be short to detect token replay
-// - MaxLifetime: Should have reasonable upper bound
-//
-// Example:
-//
-//        RefreshTokenConfig{
-//            Duration: 168*time.Hour, // 7 days
-//            RotationEnabled: true,
-//            ReuseInterval: 5*time.Minute,
-//        }
-type RefreshTokenConfig struct {
-        Duration          time.Duration // Time until token expires after issuance
-        MaxLifetime       time.Duration // Absolute maximum validity from creation
-        ReuseInterval     time.Duration // Minimum time between reuse attempts (rotation)
-        RotationEnabled   bool          // Whether to enable refresh token rotation
-        RevocationEnabled bool          // Whether to check Redis for revoked tokens
+        RotationEnabled          bool          // Whether to enable refresh token rotation (prevents token reuse)
+        RevocationEnabled        bool          // Whether to check Redis for revoked tokens
+        Algorithm                string        // JWT signing algorithm (e.g., "HS256", "RS256"). Must match key type.
+        SymmetricKey             string        // Base64-encoded secret key for HMAC (min 32 bytes for HS256)
+        PrivateKeyPath           string        // Path to PEM-encoded private key file (asymmetric only)
+        PublicKeyPath            string        // Path to PEM-encoded public key/certificate (asymmetric only)
+        Issuer                   string        // Token issuer identifier (e.g., "auth.example.com")
+        Audience                 []string      // Intended recipients (e.g., ["api.example.com"])
+        AllowedAlgorithms        []string      // Whitelist of acceptable algorithms for verification
+        RequiredClaims           []string      // Mandatory claims that must be present and valid
+        SigningMethod            SigningMethod // Cryptographic method (Symmetric/Asymmetric)
+        AccessExpiryDuration     time.Duration // Time until token expires after issuance (e.g., 30m)
+        AccessMaxLifetimeExpiry  time.Duration // Absolute maximum validity from creation (e.g., 24h)
+        RefreshExpiryDuration    time.Duration // Time until token expires after issuance
+        RefreshMaxLifetimeExpiry time.Duration // Absolute maximum validity from creation
+        RefreshReuseInterval     time.Duration // Minimum time between reuse attempts (rotation)
 }
 
 // NewGourdianTokenConfig constructs a complete token configuration with explicit settings.
@@ -209,129 +187,108 @@ type RefreshTokenConfig struct {
 // relying on defaults. For most cases, DefaultGourdianTokenConfig() is recommended.
 //
 // Parameters:
-//   - algorithm: JWT signing algorithm name (e.g., "HS256")
 //   - signingMethod: Cryptographic method type (Symmetric/Asymmetric)
+//   - rotationEnabled: Whether refresh token rotation is enabled
+//   - revocationEnabled: Whether token revocation checks are enabled
+//   - audience: List of intended token recipients
+//   - allowedAlgorithms: Whitelist of acceptable JWT algorithms
+//   - requiredClaims: Mandatory claims that must be present
+//   - algorithm: JWT signing algorithm name (e.g., "HS256")
 //   - symmetricKey: Secret key for HMAC (base64 encoded)
 //   - privateKeyPath: File path to private key (asymmetric)
 //   - publicKeyPath: File path to public key (asymmetric)
-//   - accessDuration: Access token validity duration
-//   - accessMaxLifetime: Access token absolute max lifetime
-//   - [remaining parameters...]
+//   - issuer: Token issuer identifier
+//   - accessExpiryDuration: Access token validity duration
+//   - accessMaxLifetimeExpiry: Access token absolute max lifetime
+//   - refreshExpiryDuration: Refresh token validity duration
+//   - refreshMaxLifetimeExpiry: Refresh token absolute max lifetime
+//   - refreshReuseInterval: Minimum time between refresh token reuse attempts
 //
 // Example:
 //
 //        config := NewGourdianTokenConfig(
-//            "RS256",
 //            Asymmetric,
+//            true,
+//            true,
+//            []string{"api.example.com"},
+//            []string{"RS256", "ES256"},
+//            []string{"iss", "aud", "exp"},
+//            "RS256",
 //            "",
 //            "/path/to/private.pem",
 //            "/path/to/public.pem",
+//            "auth.example.com",
 //            30*time.Minute,
 //            24*time.Hour,
-//            "auth.example.com",
-//            []string{"api.example.com"},
-//            []string{"RS256"},
-//            []string{"jti", "sub", "exp"},
-//            true,
 //            168*time.Hour,
 //            720*time.Hour,
 //            5*time.Minute,
-//            true,
-//            true,
 //        )
 func NewGourdianTokenConfig(
-        algorithm string,
         signingMethod SigningMethod,
-        symmetricKey string,
-        privateKeyPath string,
-        publicKeyPath string,
-        accessDuration time.Duration,
-        accessMaxLifetime time.Duration,
-        accessIssuer string,
-        accessAudience []string,
-        accessAllowedAlgorithms []string,
-        accessRequiredClaims []string,
-        accessRevocationEnabled bool,
-        refreshDuration time.Duration,
-        refreshMaxLifetime time.Duration,
-        refreshReuseInterval time.Duration,
-        refreshRotationEnabled bool,
-        refreshRevocationEnabled bool,
+        rotationEnabled, revocationEnabled bool,
+        audience, allowedAlgorithms, requiredClaims []string,
+        algorithm, symmetricKey, privateKeyPath, publicKeyPath, issuer string,
+        accessExpiryDuration, accessMaxLifetimeExpiry, refreshExpiryDuration, refreshMaxLifetimeExpiry, refreshReuseInterval time.Duration,
 ) GourdianTokenConfig <span class="cov0" title="0">{
         return GourdianTokenConfig{
-                Algorithm:      algorithm,
-                SigningMethod:  signingMethod,
-                SymmetricKey:   symmetricKey,
-                PrivateKeyPath: privateKeyPath,
-                PublicKeyPath:  publicKeyPath,
-                AccessToken: AccessTokenConfig{
-                        Duration:          accessDuration,
-                        MaxLifetime:       accessMaxLifetime,
-                        Issuer:            accessIssuer,
-                        Audience:          accessAudience,
-                        AllowedAlgorithms: accessAllowedAlgorithms,
-                        RequiredClaims:    accessRequiredClaims,
-                        RevocationEnabled: accessRevocationEnabled,
-                },
-                RefreshToken: RefreshTokenConfig{
-                        Duration:          refreshDuration,
-                        MaxLifetime:       refreshMaxLifetime,
-                        ReuseInterval:     refreshReuseInterval,
-                        RotationEnabled:   refreshRotationEnabled,
-                        RevocationEnabled: refreshRevocationEnabled,
-                },
+                RevocationEnabled:        revocationEnabled,
+                RotationEnabled:          rotationEnabled,
+                SigningMethod:            signingMethod,
+                Audience:                 audience,
+                AllowedAlgorithms:        allowedAlgorithms,
+                RequiredClaims:           requiredClaims,
+                Algorithm:                algorithm,
+                SymmetricKey:             symmetricKey,
+                PrivateKeyPath:           privateKeyPath,
+                PublicKeyPath:            publicKeyPath,
+                Issuer:                   issuer,
+                AccessExpiryDuration:     accessExpiryDuration,
+                AccessMaxLifetimeExpiry:  accessMaxLifetimeExpiry,
+                RefreshExpiryDuration:    refreshExpiryDuration,
+                RefreshMaxLifetimeExpiry: refreshMaxLifetimeExpiry,
+                RefreshReuseInterval:     refreshReuseInterval,
         }
 }</span>
 
-// DefaultGourdianTokenConfig returns a secure default configuration using HMAC-SHA256.
+// DefaultGourdianTokenConfig creates a secure default configuration with HMAC-SHA256.
 //
-// This configuration:
-// - Uses HS256 symmetric signing
-// - Sets 30-minute access tokens
-// - Sets 7-day refresh tokens
-// - Disables revocation/rotation by default
+// This configuration is suitable for most applications and provides:
+// - 30 minute access tokens
+// - 7 day refresh tokens
+// - Basic security requirements
 //
-// Important: The symmetricKey parameter must be at least 32 bytes for HS256 security.
-// Consider using crypto/rand to generate a strong key.
+// Parameters:
+//   - symmetricKey: Base64-encoded secret key (minimum 32 bytes)
 //
 // Example:
 //
-//        key := base64.RawURLEncoding.EncodeToString(generateRandomBytes(32))
-//        config := DefaultGourdianTokenConfig(key)
+//        config := DefaultGourdianTokenConfig("my-very-secure-base64-encoded-secret-key")
 func DefaultGourdianTokenConfig(symmetricKey string) GourdianTokenConfig <span class="cov8" title="1">{
         return GourdianTokenConfig{
-                Algorithm:      "HS256",
-                SigningMethod:  Symmetric,
-                SymmetricKey:   symmetricKey,
-                PrivateKeyPath: "",
-                PublicKeyPath:  "",
-                AccessToken: AccessTokenConfig{
-                        Duration:          30 * time.Minute,
-                        MaxLifetime:       24 * time.Hour,
-                        Issuer:            "",
-                        Audience:          nil,
-                        AllowedAlgorithms: []string{"HS256"},
-                        RequiredClaims:    []string{"jti", "sub", "exp", "iat", "typ", "rls"},
-                        RevocationEnabled: false,
-                },
-                RefreshToken: RefreshTokenConfig{
-                        Duration:          7 * 24 * time.Hour,
-                        MaxLifetime:       30 * 24 * time.Hour,
-                        ReuseInterval:     time.Minute,
-                        RotationEnabled:   false,
-                        RevocationEnabled: false,
-                },
+                RevocationEnabled:        false,
+                RotationEnabled:          false,
+                SigningMethod:            Symmetric,
+                Algorithm:                "HS256",
+                SymmetricKey:             symmetricKey,
+                PrivateKeyPath:           "",
+                PublicKeyPath:            "",
+                Issuer:                   "gourdian.com",
+                Audience:                 nil,
+                AllowedAlgorithms:        []string{"HS256", "HS384", "HS512", "RS256", "ES256", "PS256"},
+                RequiredClaims:           []string{"iss", "aud", "nbf", "mle"},
+                AccessExpiryDuration:     30 * time.Minute,
+                AccessMaxLifetimeExpiry:  24 * time.Hour,
+                RefreshExpiryDuration:    7 * 24 * time.Hour,
+                RefreshMaxLifetimeExpiry: 30 * 24 * time.Hour,
+                RefreshReuseInterval:     5 * time.Minute,
         }
 }</span>
 
 // AccessTokenClaims represents the decoded payload of an access token.
 //
-// Contains standard JWT claims (exp, iat, etc.) plus custom claims for:
-// - User identification (sub, usr)
-// - Session tracking (sid)
-// - Authorization (rls)
-//
-// The claims use abbreviated names (3 chars) to minimize token size.
+// Contains standard JWT claims plus authorization roles and session identifiers.
+// Access tokens are short-lived and carry the user's permissions.
 //
 // Example JSON Structure:
 //
@@ -340,20 +297,28 @@ func DefaultGourdianTokenConfig(symmetricKey string) GourdianTokenConfig <span c
 //            "sub": "123e4567-e89b-12d3-a456-426614174000",
 //            "usr": "alice",
 //            "sid": "123e4567-e89b-12d3-a456-426614174000",
+//            "iss": "auth.example.com",
+//            "aud": ["api.example.com"],
+//            "rls": ["user", "admin"],
 //            "iat": 1516239022,
-//            "exp": 1516242622,
-//            "typ": "access",
-//            "rls": ["admin", "user"]
+//            "exp": 1516239322,
+//            "nbf": 1516239022,
+//            "mle": 1516325422,
+//            "typ": "access"
 //        }
 type AccessTokenClaims struct {
-        ID        uuid.UUID `json:"jti"` // Unique token identifier (UUIDv4)
-        Subject   uuid.UUID `json:"sub"` // Subject (user UUID)
-        Username  string    `json:"usr"` // Human-readable username
-        SessionID uuid.UUID `json:"sid"` // Session identifier (UUIDv4)
-        IssuedAt  time.Time `json:"iat"` // Issuance timestamp (UTC)
-        ExpiresAt time.Time `json:"exp"` // Expiration timestamp (UTC)
-        TokenType TokenType `json:"typ"` // Fixed value "access"
-        Roles     []string  `json:"rls"` // Authorization roles
+        ID                uuid.UUID `json:"jti"` // Unique token identifier (UUIDv4)
+        Subject           uuid.UUID `json:"sub"` // Subject (user UUID)
+        SessionID         uuid.UUID `json:"sid"` // Session identifier (UUIDv4)
+        Username          string    `json:"usr"` // Human-readable username
+        Issuer            string    `json:"iss"` // Issuer identifier (e.g., "auth.example.com")
+        Audience          []string  `json:"aud"` // Intended audience (e.g., ["api.example.com"])
+        Roles             []string  `json:"rls"` // Authorization roles
+        IssuedAt          time.Time `json:"iat"` // Issuance timestamp (UTC)
+        ExpiresAt         time.Time `json:"exp"` // Expiration timestamp (UTC)
+        NotBefore         time.Time `json:"nbf"` // Not before timestamp (optional)
+        MaxLifetimeExpiry time.Time `json:"mle"` // Maximum lifetime expiry timestamp (RFC3339)
+        TokenType         TokenType `json:"typ"` // Fixed value "access"
 }
 
 // RefreshTokenClaims represents the decoded payload of a refresh token.
@@ -368,99 +333,118 @@ type AccessTokenClaims struct {
 //            "sub": "123e4567-e89b-12d3-a456-426614174000",
 //            "usr": "alice",
 //            "sid": "123e4567-e89b-12d3-a456-426614174000",
+//            "iss": "auth.example.com",
+//            "aud": ["api.example.com"],
 //            "iat": 1516239022,
 //            "exp": 1516242622,
+//            "nbf": 1516239022,
+//            "mle": 1516325422,
 //            "typ": "refresh"
 //        }
 type RefreshTokenClaims struct {
-        ID        uuid.UUID `json:"jti"` // Unique token identifier
-        Subject   uuid.UUID `json:"sub"` // Subject (user UUID)
-        Username  string    `json:"usr"` // Human-readable username
-        SessionID uuid.UUID `json:"sid"` // Session identifier
-        IssuedAt  time.Time `json:"iat"` // Issuance timestamp
-        ExpiresAt time.Time `json:"exp"` // Expiration timestamp
-        TokenType TokenType `json:"typ"` // Fixed value "refresh"
+        ID                uuid.UUID `json:"jti"` // Unique token identifier
+        Subject           uuid.UUID `json:"sub"` // Subject (user UUID)
+        SessionID         uuid.UUID `json:"sid"` // Session identifier
+        Username          string    `json:"usr"` // Human-readable username
+        Issuer            string    `json:"iss"` // Issuer identifier (e.g., "auth.example.com")
+        Audience          []string  `json:"aud"` // Intended audience (e.g., ["api.example.com"])
+        IssuedAt          time.Time `json:"iat"` // Issuance timestamp
+        ExpiresAt         time.Time `json:"exp"` // Expiration timestamp
+        NotBefore         time.Time `json:"nbf"` // Not before timestamp (optional)
+        MaxLifetimeExpiry time.Time `json:"mle"` // Maximum lifetime expiry timestamp (RFC3339)
+        TokenType         TokenType `json:"typ"` // Fixed value "refresh"
 }
 
-// AccessTokenResponse contains the results of a successful access token generation.
+// AccessTokenResponse contains all information about a newly created access token.
 //
-// This struct serves as both the return value from CreateAccessToken and as a
-// potential API response format. It includes both the raw token and metadata.
+// This struct is returned when creating new access tokens and includes both
+// the signed token string and all its decoded claims for client convenience.
 //
-// Example JSON Response:
+// Example:
 //
-//        {
-//            "tok": "eyJhbGciOi...",
-//            "sub": "123e4567-e89b-12d3-a456-426614174000",
-//            "usr": "alice",
-//            "sid": "123e4567-e89b-12d3-a456-426614174000",
-//            "exp": "2023-01-01T12:00:00Z",
-//            "iat": "2023-01-01T11:30:00Z",
-//            "rls": ["admin", "user"]
+//        response := AccessTokenResponse{
+//            Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+//            Subject:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+//            SessionID: uuid.MustParse("223e4567-e89b-12d3-a456-426614174000"),
+//            Issuer:    "auth.example.com",
+//            ExpiresAt: time.Now().Add(30 * time.Minute),
+//            // ... other fields
 //        }
 type AccessTokenResponse struct {
-        Token     string    `json:"tok"` // Signed JWT string
-        Subject   uuid.UUID `json:"sub"` // User UUID
-        Username  string    `json:"usr"` // Username
-        SessionID uuid.UUID `json:"sid"` // Session UUID
-        ExpiresAt time.Time `json:"exp"` // Expiration timestamp (RFC3339)
-        IssuedAt  time.Time `json:"iat"` // Issuance timestamp (RFC3339)
-        Roles     []string  `json:"rls"` // Authorization roles
+        Subject           uuid.UUID `json:"sub"` // User UUID
+        SessionID         uuid.UUID `json:"sid"` // Session UUID
+        Token             string    `json:"tok"` // Signed JWT string
+        Issuer            string    `json:"iss"` // Issuer identifier
+        Username          string    `json:"usr"` // Username
+        Roles             []string  `json:"rls"` // Authorization roles
+        Audience          []string  `json:"aud"` // Intended audience
+        IssuedAt          time.Time `json:"iat"` // Issuance timestamp (RFC3339)
+        ExpiresAt         time.Time `json:"exp"` // Expiration timestamp (RFC3339)
+        NotBefore         time.Time `json:"nbf"` // Not before timestamp (optional)
+        MaxLifetimeExpiry time.Time `json:"mle"` // Maximum lifetime expiry timestamp (RFC3339)
+        TokenType         TokenType `json:"typ"` // Fixed value "access"
 }
 
-// RefreshTokenResponse contains the results of refresh token generation or rotation.
+// RefreshTokenResponse contains all information about a newly created refresh token.
 //
-// Similar to AccessTokenResponse but without roles since refresh tokens don't carry
-// authorization claims.
+// Similar to AccessTokenResponse but without roles, since refresh tokens
+// don't carry authorization information.
 //
-// Example JSON Response:
+// Example:
 //
-//        {
-//            "tok": "eyJhbGciOi...",
-//            "sub": "123e4567-e89b-12d3-a456-426614174000",
-//            "usr": "alice",
-//            "sid": "123e4567-e89b-12d3-a456-426614174000",
-//            "exp": "2023-01-08T11:30:00Z",
-//            "iat": "2023-01-01T11:30:00Z"
+//        response := RefreshTokenResponse{
+//            Token:     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+//            Subject:   uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+//            SessionID: uuid.MustParse("223e4567-e89b-12d3-a456-426614174000"),
+//            Issuer:    "auth.example.com",
+//            ExpiresAt: time.Now().Add(168 * time.Hour),
+//            // ... other fields
 //        }
 type RefreshTokenResponse struct {
-        Token     string    `json:"tok"` // Signed JWT string
-        Subject   uuid.UUID `json:"sub"` // User UUID
-        Username  string    `json:"usr"` // Username
-        SessionID uuid.UUID `json:"sid"` // Session UUID
-        ExpiresAt time.Time `json:"exp"` // Expiration timestamp
-        IssuedAt  time.Time `json:"iat"` // Issuance timestamp
+        Subject           uuid.UUID `json:"sub"` // User UUID
+        SessionID         uuid.UUID `json:"sid"` // Session UUID
+        Token             string    `json:"tok"` // Signed JWT string
+        Issuer            string    `json:"iss"` // Issuer identifier
+        Username          string    `json:"usr"` // Username
+        Audience          []string  `json:"aud"` // Intended audience
+        IssuedAt          time.Time `json:"iat"` // Issuance timestamp
+        ExpiresAt         time.Time `json:"exp"` // Expiration timestamp
+        NotBefore         time.Time `json:"nbf"` // Not before timestamp
+        MaxLifetimeExpiry time.Time `json:"mle"` // Maximum lifetime expiry timestamp (RFC3339)
+        TokenType         TokenType `json:"typ"` // Fixed value "access"
 }
 
-// GourdianTokenMaker defines the interface for generating and verifying secure access and refresh tokens.
+// GourdianTokenMaker defines the interface for token operations.
 //
-// Any implementation (e.g., JWTMaker) must satisfy this interface to provide
-// token creation, verification, revocation, and rotation capabilities.
-//
-// Example usage:
-//
-//        access, err := maker.CreateAccessToken(ctx, userID, "username", []string{"admin"}, sessionID)
-//        refresh, err := maker.CreateRefreshToken(ctx, userID, "username", sessionID)
+// Implementations should provide thread-safe methods for creating,
+// verifying, and managing JWT tokens according to the configured policies.
 type GourdianTokenMaker interface {
+        // CreateAccessToken generates a new signed access token
         CreateAccessToken(ctx context.Context, userID uuid.UUID, username string, roles []string, sessionID uuid.UUID) (*AccessTokenResponse, error)
+
+        // CreateRefreshToken generates a new signed refresh token
         CreateRefreshToken(ctx context.Context, userID uuid.UUID, username string, sessionID uuid.UUID) (*RefreshTokenResponse, error)
+
+        // VerifyAccessToken validates and parses an access token
         VerifyAccessToken(ctx context.Context, tokenString string) (*AccessTokenClaims, error)
+
+        // VerifyRefreshToken validates and parses a refresh token
         VerifyRefreshToken(ctx context.Context, tokenString string) (*RefreshTokenClaims, error)
+
+        // RevokeAccessToken marks an access token as revoked
         RevokeAccessToken(ctx context.Context, token string) error
+
+        // RevokeRefreshToken marks a refresh token as revoked
         RevokeRefreshToken(ctx context.Context, token string) error
+
+        // RotateRefreshToken exchanges an old refresh token for a new one
         RotateRefreshToken(ctx context.Context, oldToken string) (*RefreshTokenResponse, error)
 }
 
-// JWTMaker is the concrete implementation of GourdianTokenMaker using JWT.
+// JWTMaker is the concrete implementation of GourdianTokenMaker.
 //
-// This struct maintains:
-// - Cryptographic configuration and keys
-// - Redis connection for advanced features
-// - Token generation/verification state
-//
-// Security Note:
-// The privateKey field contains sensitive key material and should be protected
-// from memory inspection in secure environments.
+// This private struct holds the actual implementation details including
+// cryptographic keys and Redis connections for advanced features.
 type JWTMaker struct {
         config        GourdianTokenConfig // Immutable configuration
         signingMethod jwt.SigningMethod   // JWT signing algorithm instance
@@ -469,35 +453,42 @@ type JWTMaker struct {
         redisClient   *redis.Client       // Redis client for revocation/rotation
 }
 
-// NewGourdianTokenMaker creates a new token maker instance with the provided configuration.
+// NewGourdianTokenMaker creates a new token maker with custom configuration.
 //
-// This is the primary initialization function that:
-// 1. Validates the configuration
-// 2. Initializes cryptographic keys
-// 3. Sets up Redis connection if rotation/revocation is enabled
-// 4. Returns a ready-to-use token maker
+// This is the primary constructor that sets up all cryptographic materials
+// and verifies the configuration is valid before use.
 //
 // Parameters:
+//   - ctx: Context for cancellation/timeout
 //   - config: Complete token configuration
-//   - redisOpts: Redis options (required if Redis-based features like rotation/revocation are enabled)
-//
-// Returns:
-// A fully initialized GourdianTokenMaker or error.
+//   - redisOpts: Redis connection options (required for revocation/rotation)
 //
 // Example:
 //
-//        config := DefaultGourdianTokenConfig("your-secret-key")
-//        redisOpts := &amp;redis.Options{ Addr: "localhost:6379" }
-//        maker, err := NewGourdianTokenMaker(ctx, config, redisOpts)
+//        config := DefaultGourdianTokenConfig("my-secret-key")
+//        maker, err := NewGourdianTokenMaker(context.Background(), config, &amp;redis.Options{
+//            Addr: "localhost:6379",
+//        })
+//        if err != nil {
+//            log.Fatal(err)
+//        }
 func NewGourdianTokenMaker(ctx context.Context, config GourdianTokenConfig, redisOpts *redis.Options) (GourdianTokenMaker, error) <span class="cov8" title="1">{
+        // Check context cancellation first
+        if err := ctx.Err(); err != nil </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("context canceled: %w", err)
+        }</span>
+
         // Validate configuration
-        if err := validateConfig(&amp;config); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if err := validateConfig(&amp;config); err != nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid config: %w", err)
         }</span>
 
+        <span class="cov8" title="1">if err := validateAlgorithmAndMethod(&amp;config); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("invalid algorithm/method combination: %w", err)
+        }</span>
+
         // Check Redis requirements
-        <span class="cov8" title="1">if (config.RefreshToken.RotationEnabled || config.RefreshToken.RevocationEnabled ||
-                config.AccessToken.RevocationEnabled) &amp;&amp; redisOpts == nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if (config.RotationEnabled || config.RevocationEnabled) &amp;&amp; redisOpts == nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("redis options required for token rotation/revocation")
         }</span>
 
@@ -506,8 +497,7 @@ func NewGourdianTokenMaker(ctx context.Context, config GourdianTokenConfig, redi
         }
 
         // Initialize Redis client if any feature requiring Redis is enabled
-        if config.RefreshToken.RotationEnabled || config.RefreshToken.RevocationEnabled ||
-                config.AccessToken.RevocationEnabled </span><span class="cov8" title="1">{
+        if config.RotationEnabled || config.RevocationEnabled </span><span class="cov8" title="1">{
                 maker.redisClient = redis.NewClient(redisOpts)
 
                 // Verify Redis connection with the provided context
@@ -515,11 +505,16 @@ func NewGourdianTokenMaker(ctx context.Context, config GourdianTokenConfig, redi
                         return nil, fmt.Errorf("redis connection failed: %w", err)
                 }</span>
 
+                // Check context again before starting goroutines
+                <span class="cov8" title="1">if err := ctx.Err(); err != nil </span><span class="cov0" title="0">{
+                        return nil, fmt.Errorf("context canceled: %w", err)
+                }</span>
+
                 // Set up background cleanup if needed
-                <span class="cov8" title="1">if config.RefreshToken.RotationEnabled </span><span class="cov8" title="1">{
+                <span class="cov8" title="1">if config.RotationEnabled </span><span class="cov8" title="1">{
                         go maker.cleanupRotatedTokens(ctx)
                 }</span>
-                <span class="cov8" title="1">if config.RefreshToken.RevocationEnabled || config.AccessToken.RevocationEnabled </span><span class="cov8" title="1">{
+                <span class="cov8" title="1">if config.RevocationEnabled </span><span class="cov8" title="1">{
                         go maker.cleanupRevokedTokens(ctx)
                 }</span>
         }
@@ -537,94 +532,82 @@ func NewGourdianTokenMaker(ctx context.Context, config GourdianTokenConfig, redi
         <span class="cov8" title="1">return maker, nil</span>
 }
 
-// NewGourdianTokenMakerWithDefaults creates a new token maker with secure defaults
-// using HMAC-SHA256 (HS256) symmetric signing. When Redis options are provided,
-// it automatically enables revocation and rotation features.
+// DefaultGourdianTokenMaker creates a token maker with secure defaults.
 //
-// Default Configuration:
-//   - Algorithm: HS256 (HMAC-SHA256)
-//   - Signing: Symmetric (using provided key)
-//   - Access Token:
-//   - Lifetime: 30 minutes
-//   - Max Lifetime: 24 hours
-//   - Required Claims: jti, sub, exp, iat, typ, rls
-//   - Revocation: Disabled (enabled if Redis provided)
-//   - Refresh Token:
-//   - Lifetime: 7 days
-//   - Max Lifetime: 30 days
-//   - Reuse Interval: 1 minute
-//   - Rotation: Disabled (enabled if Redis provided)
-//   - Revocation: Disabled (enabled if Redis provided)
-//
-// Security automatically enhanced when Redis is provided:
-//   - Access token revocation
-//   - Refresh token revocation
-//   - Refresh token rotation
+// This convenience constructor uses HMAC-SHA256 with the provided symmetric key
+// and optional Redis connection for advanced features.
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - symmetricKey: Base64-encoded secret key (min 32 bytes for HS256 security)
-//   - redisOpts: Optional Redis configuration (nil disables advanced features)
-//
-// Returns:
-//   - Initialized GourdianTokenMaker instance
-//   - Error if configuration or initialization fails
-//
-// Example without Redis:
-//
-//        maker, err := NewGourdianTokenMakerWithDefaults(ctx, key, nil)
-//
-// Example with Redis:
-//
-//        redisOpts := &amp;redis.Options{Addr: "localhost:6379"}
-//        maker, err := NewGourdianTokenMakerWithDefaults(ctx, key, redisOpts)
-func NewGourdianTokenMakerWithDefaults(
-        ctx context.Context,
-        symmetricKey string,
-        redisOpts *redis.Options,
-) (GourdianTokenMaker, error) <span class="cov0" title="0">{
-        config := DefaultGourdianTokenConfig(symmetricKey)
-        if redisOpts != nil </span><span class="cov0" title="0">{
-                config.AccessToken.RevocationEnabled = true
-                config.RefreshToken.RevocationEnabled = true
-                config.RefreshToken.RotationEnabled = true
-        }</span>
-        <span class="cov0" title="0">return NewGourdianTokenMaker(ctx, config, redisOpts)</span>
-}
-
-// CreateAccessToken generates a new JWT access token containing the user's identity and authorization claims.
-// The token is signed using the maker's private key and includes standard JWT claims along with custom claims
-// for roles and session management. The token expiration is determined by the maker's configuration.
-//
-// Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - userID: Unique identifier for the user (UUID)
-//   - username: Human-readable user identifier
-//   - roles: List of authorization roles granted to the user (cannot be empty)
-//   - sessionID: Unique identifier for the user's session
-//
-// Returns:
-//   - AccessTokenResponse containing the signed token string and metadata
-//   - Error if input validation fails, cryptographic operations fail, or token generation fails
+//   - ctx: Context for cancellation/timeout
+//   - symmetricKey: Base64-encoded secret key (minimum 32 bytes)
+//   - redisOpts: Optional Redis connection options
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        userID := uuid.MustParse("a1b2c3d4-e5f6-7890-g1h2-i3j4k5l6m7n8")
-//        sessionID := uuid.New()
-//        token, err := maker.CreateAccessToken(
-//            ctx,
-//            userID,
-//            "john_doe",
-//            []string{"admin", "editor"},
-//            sessionID,
+//        maker, err := DefaultGourdianTokenMaker(
+//            context.Background(),
+//            "my-very-secure-base64-encoded-secret-key",
+//            &amp;redis.Options{Addr: "localhost:6379"},
 //        )
-//        if err != nil {
-//            log.Fatal(err)
-//        }
-//        fmt.Printf("Generated access token: %s\n", token.Token)
+func DefaultGourdianTokenMaker(
+        ctx context.Context,
+        symmetricKey string,
+        redisOpts *redis.Options,
+) (GourdianTokenMaker, error) <span class="cov8" title="1">{
+        config := GourdianTokenConfig{
+                RevocationEnabled:        false,
+                RotationEnabled:          false,
+                Algorithm:                "HS256",
+                SymmetricKey:             symmetricKey,
+                PrivateKeyPath:           "",
+                PublicKeyPath:            "",
+                Issuer:                   "gourdian.com",
+                Audience:                 nil,
+                AllowedAlgorithms:        []string{"HS256", "RS256", "ES256", "PS256"},
+                RequiredClaims:           []string{"iss", "aud", "nbf", "mle"},
+                SigningMethod:            Symmetric,
+                AccessExpiryDuration:     30 * time.Minute,
+                AccessMaxLifetimeExpiry:  24 * time.Hour,
+                RefreshExpiryDuration:    7 * 24 * time.Hour,
+                RefreshMaxLifetimeExpiry: 30 * 24 * time.Hour,
+                RefreshReuseInterval:     5 * time.Minute,
+        }
+
+        if redisOpts != nil </span><span class="cov8" title="1">{
+                config.RevocationEnabled = true
+                config.RotationEnabled = true
+        }</span>
+        <span class="cov8" title="1">return NewGourdianTokenMaker(ctx, config, redisOpts)</span>
+}
+
+// CreateAccessToken generates a new signed access token with the given user attributes.
+//
+// The token will include all standard claims plus the provided roles and session information.
+// It will be signed using the configured cryptographic method.
+//
+// Parameters:
+//   - ctx: Context for cancellation/timeout
+//   - userID: Unique identifier for the user (UUID)
+//   - username: Human-readable username
+//   - roles: Authorization roles assigned to the user
+//   - sessionID: Unique session identifier (UUID)
+//
+// Example:
+//
+//        token, err := maker.CreateAccessToken(
+//            context.Background(),
+//            uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+//            "alice",
+//            []string{"user", "admin"},
+//            uuid.MustParse("223e4567-e89b-12d3-a456-426614174000"),
+//        )
 func (maker *JWTMaker) CreateAccessToken(ctx context.Context, userID uuid.UUID, username string, roles []string, sessionID uuid.UUID) (*AccessTokenResponse, error) <span class="cov8" title="1">{
-        if userID == uuid.Nil </span><span class="cov8" title="1">{
+
+        if err := ctx.Err(); err != nil </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("context canceled: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if userID == uuid.Nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid user ID: cannot be empty")
         }</span>
         <span class="cov8" title="1">if len(roles) == 0 </span><span class="cov8" title="1">{
@@ -648,14 +631,18 @@ func (maker *JWTMaker) CreateAccessToken(ctx context.Context, userID uuid.UUID, 
 
         <span class="cov8" title="1">now := time.Now()
         claims := AccessTokenClaims{
-                ID:        tokenID,
-                Subject:   userID,
-                Username:  username,
-                SessionID: sessionID,
-                IssuedAt:  now,
-                ExpiresAt: now.Add(maker.config.AccessToken.Duration),
-                TokenType: AccessToken,
-                Roles:     roles,
+                ID:                tokenID,
+                Subject:           userID,
+                SessionID:         sessionID,
+                Username:          username,
+                Issuer:            maker.config.Issuer,
+                Audience:          maker.config.Audience,
+                Roles:             roles,
+                IssuedAt:          now,
+                ExpiresAt:         now.Add(maker.config.AccessExpiryDuration),
+                NotBefore:         now,
+                MaxLifetimeExpiry: now.Add(maker.config.AccessMaxLifetimeExpiry),
+                TokenType:         AccessToken,
         }
 
         token := jwt.NewWithClaims(maker.signingMethod, toMapClaims(claims))
@@ -666,53 +653,52 @@ func (maker *JWTMaker) CreateAccessToken(ctx context.Context, userID uuid.UUID, 
         }</span>
 
         <span class="cov8" title="1">response := &amp;AccessTokenResponse{
-                Token:     signedToken,
-                Subject:   claims.Subject,
-                Username:  claims.Username,
-                SessionID: claims.SessionID,
-                ExpiresAt: claims.ExpiresAt,
-                IssuedAt:  claims.IssuedAt,
-                Roles:     roles,
+                Subject:           claims.Subject,
+                SessionID:         claims.SessionID,
+                Token:             signedToken,
+                Issuer:            claims.Issuer,
+                Username:          claims.Username,
+                Roles:             roles,
+                Audience:          claims.Audience,
+                IssuedAt:          claims.IssuedAt,
+                ExpiresAt:         claims.ExpiresAt,
+                NotBefore:         claims.NotBefore,
+                MaxLifetimeExpiry: claims.MaxLifetimeExpiry,
+                TokenType:         claims.TokenType,
         }
 
         return response, nil</span>
 }
 
-// CreateRefreshToken generates a long-lived refresh token used to obtain new access tokens without
-// requiring re-authentication. Refresh tokens have different security characteristics than access tokens
-// and are typically stored more securely. The token includes the user's identity and session information
-// but no role claims.
+// CreateRefreshToken generates a new signed refresh token with the given user attributes.
+//
+// Refresh tokens are longer-lived than access tokens but contain no authorization
+// roles since they're only used to obtain new access tokens.
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
+//   - ctx: Context for cancellation/timeout
 //   - userID: Unique identifier for the user (UUID)
-//   - username: Human-readable user identifier
-//   - sessionID: Unique identifier for the user's session
-//
-// Returns:
-//   - RefreshTokenResponse containing the signed token string and metadata
-//   - Error if input validation fails or token generation fails
+//   - username: Human-readable username
+//   - sessionID: Unique session identifier (UUID)
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        userID := uuid.MustParse("a1b2c3d4-e5f6-7890-g1h2-i3j4k5l6m7n8")
-//        sessionID := uuid.New()
 //        token, err := maker.CreateRefreshToken(
-//            ctx,
-//            userID,
-//            "john_doe",
-//            sessionID,
+//            context.Background(),
+//            uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+//            "alice",
+//            uuid.MustParse("223e4567-e89b-12d3-a456-426614174000"),
 //        )
-//        if err != nil {
-//            log.Fatal(err)
-//        }
-//        fmt.Printf("Generated refresh token: %s (expires %v)\n", token.Token, token.ExpiresAt)
 func (maker *JWTMaker) CreateRefreshToken(ctx context.Context, userID uuid.UUID, username string, sessionID uuid.UUID) (*RefreshTokenResponse, error) <span class="cov8" title="1">{
-        if userID == uuid.Nil </span><span class="cov8" title="1">{
+
+        if err := ctx.Err(); err != nil </span><span class="cov8" title="1">{
+                return nil, fmt.Errorf("context canceled: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if userID == uuid.Nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid user ID: cannot be empty")
         }</span>
-        <span class="cov8" title="1">if len(username) &gt; 1024 </span><span class="cov0" title="0">{
+        <span class="cov8" title="1">if len(username) &gt; 1024 </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("username too long: max 1024 characters")
         }</span>
 
@@ -723,13 +709,17 @@ func (maker *JWTMaker) CreateRefreshToken(ctx context.Context, userID uuid.UUID,
 
         <span class="cov8" title="1">now := time.Now()
         claims := RefreshTokenClaims{
-                ID:        tokenID,
-                Subject:   userID,
-                Username:  username,
-                SessionID: sessionID,
-                IssuedAt:  now,
-                ExpiresAt: now.Add(maker.config.RefreshToken.Duration),
-                TokenType: RefreshToken,
+                ID:                tokenID,
+                Subject:           userID,
+                SessionID:         sessionID,
+                Username:          username,
+                Issuer:            maker.config.Issuer,
+                Audience:          maker.config.Audience,
+                IssuedAt:          now,
+                ExpiresAt:         now.Add(maker.config.RefreshExpiryDuration),
+                NotBefore:         now,
+                MaxLifetimeExpiry: now.Add(maker.config.RefreshMaxLifetimeExpiry),
+                TokenType:         RefreshToken,
         }
 
         token := jwt.NewWithClaims(maker.signingMethod, toMapClaims(claims))
@@ -740,42 +730,46 @@ func (maker *JWTMaker) CreateRefreshToken(ctx context.Context, userID uuid.UUID,
         }</span>
 
         <span class="cov8" title="1">response := &amp;RefreshTokenResponse{
-                Token:     signedToken,
-                Subject:   claims.Subject,
-                Username:  claims.Username,
-                SessionID: claims.SessionID,
-                ExpiresAt: claims.ExpiresAt,
-                IssuedAt:  claims.IssuedAt,
+                Subject:           claims.Subject,
+                SessionID:         claims.SessionID,
+                Token:             signedToken,
+                Issuer:            claims.Issuer,
+                Username:          claims.Username,
+                Audience:          claims.Audience,
+                IssuedAt:          claims.IssuedAt,
+                ExpiresAt:         claims.ExpiresAt,
+                NotBefore:         claims.NotBefore,
+                MaxLifetimeExpiry: claims.MaxLifetimeExpiry,
+                TokenType:         claims.TokenType,
         }
 
         return response, nil</span>
 }
 
-// VerifyAccessToken validates an access token's signature, checks for revocation (if enabled),
-// and verifies all standard and custom claims. Returns the decoded claims if valid.
+// VerifyAccessToken validates an access token signature and claims.
+//
+// Performs full validation including:
+// - Cryptographic signature verification
+// - Expiration checks
+// - Required claim validation
+// - Revocation check (if enabled)
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - tokenString: The JWT access token string to verify
-//
-// Returns:
-//   - AccessTokenClaims containing all verified claims from the token
-//   - Error if token is invalid, expired, revoked, or malformed
+//   - ctx: Context for cancellation/timeout
+//   - tokenString: The JWT token string to verify
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        claims, err := maker.VerifyAccessToken(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+//        claims, err := maker.VerifyAccessToken(context.Background(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 //        if err != nil {
-//            log.Fatal("Token verification failed:", err)
+//            // Handle invalid token
 //        }
-//        fmt.Printf("Valid token for user %s with roles %v\n", claims.Username, claims.Roles)
 func (maker *JWTMaker) VerifyAccessToken(ctx context.Context, tokenString string) (*AccessTokenClaims, error) <span class="cov8" title="1">{
 
-        if maker.config.AccessToken.RevocationEnabled &amp;&amp; maker.redisClient != nil </span><span class="cov8" title="1">{
+        if maker.config.RevocationEnabled &amp;&amp; maker.redisClient != nil </span><span class="cov8" title="1">{
 
-                exists, err := maker.redisClient.Exists(ctx, "revoked:access:"+tokenString).Result()
-                if err != nil </span><span class="cov0" title="0">{
+                exists, err := maker.redisClient.Exists(ctx, revokedAccessPrefix+tokenString).Result()
+                if err != nil </span><span class="cov8" title="1">{
                         return nil, fmt.Errorf("failed to check token revocation: %w", err)
                 }</span>
                 <span class="cov8" title="1">if exists &gt; 0 </span><span class="cov8" title="1">{
@@ -805,7 +799,7 @@ func (maker *JWTMaker) VerifyAccessToken(ctx context.Context, tokenString string
         }</span>
 
         // 2. Validate all required claims exist
-        <span class="cov8" title="1">if err := validateTokenClaims(claims, AccessToken); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if err := validateTokenClaims(claims, AccessToken, maker.config.RequiredClaims); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
@@ -823,34 +817,29 @@ func (maker *JWTMaker) VerifyAccessToken(ctx context.Context, tokenString string
         <span class="cov8" title="1">return accessClaims, nil</span>
 }
 
-// VerifyRefreshToken validates a refresh token's signature, checks for revocation (if enabled),
-// and verifies all standard claims. Returns the decoded claims if valid.
+// VerifyRefreshToken validates a refresh token signature and claims.
+//
+// Similar to VerifyAccessToken but with refresh-token specific validation rules.
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - tokenString: The JWT refresh token string to verify
-//
-// Returns:
-//   - RefreshTokenClaims containing all verified claims from the token
-//   - Error if token is invalid, expired, revoked, or malformed
+//   - ctx: Context for cancellation/timeout
+//   - tokenString: The JWT token string to verify
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        claims, err := maker.VerifyRefreshToken(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+//        claims, err := maker.VerifyRefreshToken(context.Background(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 //        if err != nil {
-//            log.Fatal("Token verification failed:", err)
+//            // Handle invalid token
 //        }
-//        fmt.Printf("Valid refresh token for user %s (session %v)\n", claims.Username, claims.SessionID)
 func (maker *JWTMaker) VerifyRefreshToken(ctx context.Context, tokenString string) (*RefreshTokenClaims, error) <span class="cov8" title="1">{
 
-        if maker.config.RefreshToken.RevocationEnabled &amp;&amp; maker.redisClient != nil </span><span class="cov8" title="1">{
+        if maker.config.RevocationEnabled &amp;&amp; maker.redisClient != nil </span><span class="cov8" title="1">{
 
-                exists, err := maker.redisClient.Exists(ctx, "revoked:refresh:"+tokenString).Result()
+                exists, err := maker.redisClient.Exists(ctx, revokedRefreshPrefix+tokenString).Result()
                 if err != nil </span><span class="cov0" title="0">{
                         return nil, fmt.Errorf("failed to check token revocation: %w", err)
                 }</span>
-                <span class="cov8" title="1">if exists &gt; 0 </span><span class="cov8" title="1">{
+                <span class="cov8" title="1">if exists &gt; 0 </span><span class="cov0" title="0">{
                         return nil, fmt.Errorf("token has been revoked")
                 }</span>
         }
@@ -875,34 +864,30 @@ func (maker *JWTMaker) VerifyRefreshToken(ctx context.Context, tokenString strin
                 return nil, fmt.Errorf("invalid token claims")
         }</span>
 
-        <span class="cov8" title="1">if err := validateTokenClaims(claims, RefreshToken); err != nil </span><span class="cov8" title="1">{
+        <span class="cov8" title="1">if err := validateTokenClaims(claims, RefreshToken, maker.config.RequiredClaims); err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
 
         <span class="cov8" title="1">return mapToRefreshClaims(claims)</span>
 }
 
-// RevokeAccessToken invalidates an access token before its natural expiration,
-// preventing its future use. Requires Redis-based revocation to be enabled in configuration.
-// The revocation is stored in Redis with a TTL matching the token's remaining lifetime.
+// RevokeAccessToken marks an access token as revoked in Redis.
+//
+// Revoked tokens will fail validation even if they're otherwise valid.
+// The revocation entry automatically expires when the token would have naturally expired.
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - token: The access token string to revoke
-//
-// Returns:
-//   - Error if revocation is disabled, token is invalid, or Redis operation fails
+//   - ctx: Context for cancellation/timeout
+//   - token: The token string to revoke
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        err := maker.RevokeAccessToken(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+//        err := maker.RevokeAccessToken(context.Background(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 //        if err != nil {
-//            log.Fatal("Failed to revoke token:", err)
+//            // Handle revocation failure
 //        }
-//        fmt.Println("Access token successfully revoked")
 func (maker *JWTMaker) RevokeAccessToken(ctx context.Context, token string) error <span class="cov8" title="1">{
-        if !maker.config.AccessToken.RevocationEnabled || maker.redisClient == nil </span><span class="cov8" title="1">{
+        if !maker.config.RevocationEnabled || maker.redisClient == nil </span><span class="cov8" title="1">{
                 return fmt.Errorf("access token revocation is not enabled")
         }</span>
 
@@ -926,79 +911,76 @@ func (maker *JWTMaker) RevokeAccessToken(ctx context.Context, token string) erro
         <span class="cov8" title="1">ttl := time.Until(time.Unix(exp, 0))
 
         // Store the token string as revoked in Redis with expiry
-        return maker.redisClient.Set(ctx, "revoked:access:"+token, "1", ttl).Err()</span>
+        return maker.redisClient.Set(ctx, revokedAccessPrefix+token, "1", ttl).Err()</span>
 }
 
-// RevokeRefreshToken invalidates a refresh token before its natural expiration,
-// preventing its future use for obtaining new access tokens. Requires Redis-based
-// revocation to be enabled in configuration.
+// RevokeRefreshToken marks a refresh token as revoked in Redis.
+//
+// Works similarly to RevokeAccessToken but for refresh tokens.
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - token: The refresh token string to revoke
-//
-// Returns:
-//   - Error if revocation is disabled, token is invalid, or Redis operation fails
+//   - ctx: Context for cancellation/timeout
+//   - token: The token string to revoke
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        err := maker.RevokeRefreshToken(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+//        err := maker.RevokeRefreshToken(context.Background(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 //        if err != nil {
-//            log.Fatal("Failed to revoke token:", err)
+//            // Handle revocation failure
 //        }
-//        fmt.Println("Refresh token successfully revoked")
-func (maker *JWTMaker) RevokeRefreshToken(ctx context.Context, token string) error <span class="cov8" title="1">{
-        if !maker.config.RefreshToken.RevocationEnabled || maker.redisClient == nil </span><span class="cov0" title="0">{
+func (maker *JWTMaker) RevokeRefreshToken(ctx context.Context, token string) error <span class="cov0" title="0">{
+        if !maker.config.RevocationEnabled || maker.redisClient == nil </span><span class="cov0" title="0">{
                 return fmt.Errorf("refresh token revocation is not enabled")
         }</span>
 
         // Parse the token to extract expiration time
-        <span class="cov8" title="1">parsed, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) </span><span class="cov8" title="1">{
+        <span class="cov0" title="0">parsed, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) </span><span class="cov0" title="0">{
                 return maker.publicKey, nil
         }</span>)
-        <span class="cov8" title="1">if err != nil || !parsed.Valid </span><span class="cov0" title="0">{
+        <span class="cov0" title="0">if err != nil || !parsed.Valid </span><span class="cov0" title="0">{
                 return fmt.Errorf("invalid token: %w", err)
         }</span>
 
-        <span class="cov8" title="1">claims, ok := parsed.Claims.(jwt.MapClaims)
+        <span class="cov0" title="0">claims, ok := parsed.Claims.(jwt.MapClaims)
         if !ok </span><span class="cov0" title="0">{
                 return fmt.Errorf("invalid token claims")
         }</span>
 
-        <span class="cov8" title="1">exp := getUnixTime(claims["exp"])
+        <span class="cov0" title="0">exp := getUnixTime(claims["exp"])
         if exp == 0 </span><span class="cov0" title="0">{
                 return fmt.Errorf("token missing exp claim")
         }</span>
-        <span class="cov8" title="1">ttl := time.Until(time.Unix(exp, 0))
+        <span class="cov0" title="0">ttl := time.Until(time.Unix(exp, 0))
 
         // Store the token string as revoked in Redis with expiry
-        return maker.redisClient.Set(ctx, "revoked:refresh:"+token, "1", ttl).Err()</span>
+        return maker.redisClient.Set(ctx, revokedRefreshPrefix+token, "1", ttl).Err()</span>
 }
 
-// RotateRefreshToken generates a new refresh token while invalidating the previous one,
-// implementing the refresh token rotation security practice. The old token is recorded
-// in Redis to prevent immediate reuse (detection of token replay attacks). Requires
-// rotation to be enabled in configuration.
+// RotateRefreshToken exchanges an old refresh token for a new one.
+//
+// Implements refresh token rotation by:
+// 1. Verifying the old token is valid
+// 2. Checking it hasn't been recently used
+// 3. Issuing a new refresh token
+// 4. Recording the old token to prevent reuse
 //
 // Parameters:
-//   - ctx: Context for request-scoped values, cancellations, and deadlines
-//   - oldToken: The refresh token to rotate out
-//
-// Returns:
-//   - RefreshTokenResponse containing the new refresh token and metadata
-//   - Error if rotation is disabled, old token is invalid, or Redis operation fails
+//   - ctx: Context for cancellation/timeout
+//   - oldToken: The refresh token to rotate
 //
 // Example:
 //
-//        maker, _ := NewGourdianTokenMaker(ctx, config, redisOpts)
-//        newToken, err := maker.RotateRefreshToken(ctx, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+//        newToken, err := maker.RotateRefreshToken(context.Background(), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
 //        if err != nil {
-//            log.Fatal("Failed to rotate token:", err)
+//            // Handle rotation failure
 //        }
-//        fmt.Printf("Issued new refresh token: %s (expires %v)\n", newToken.Token, newToken.ExpiresAt)
 func (maker *JWTMaker) RotateRefreshToken(ctx context.Context, oldToken string) (*RefreshTokenResponse, error) <span class="cov8" title="1">{
-        if !maker.config.RefreshToken.RotationEnabled </span><span class="cov8" title="1">{
+
+        if err := ctx.Err(); err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("context canceled: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if !maker.config.RotationEnabled </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("token rotation not enabled")
         }</span>
 
@@ -1011,7 +993,7 @@ func (maker *JWTMaker) RotateRefreshToken(ctx context.Context, oldToken string) 
                 return nil, fmt.Errorf("invalid token: %w", err)
         }</span>
 
-        <span class="cov8" title="1">tokenKey := "rotated:" + oldToken
+        <span class="cov8" title="1">tokenKey := rotatedPrefix + oldToken
 
         exists, err := maker.redisClient.Exists(ctx, tokenKey).Result()
         if err != nil </span><span class="cov0" title="0">{
@@ -1022,12 +1004,23 @@ func (maker *JWTMaker) RotateRefreshToken(ctx context.Context, oldToken string) 
                 return nil, fmt.Errorf("token reused too soon")
         }</span>
 
+        // Enforce reuse interval
+        <span class="cov8" title="1">if maker.config.RefreshReuseInterval &gt; 0 </span><span class="cov8" title="1">{
+                ttl, err := maker.redisClient.TTL(ctx, rotatedPrefix+oldToken).Result()
+                if err == nil &amp;&amp; ttl &gt; 0 </span><span class="cov0" title="0">{
+                        remaining := time.Duration(ttl) * time.Second
+                        if remaining &gt; maker.config.RefreshReuseInterval </span><span class="cov0" title="0">{
+                                return nil, fmt.Errorf("token reused too soon, wait %v", remaining)
+                        }</span>
+                }
+        }
+
         <span class="cov8" title="1">newToken, err := maker.CreateRefreshToken(ctx, claims.Subject, claims.Username, claims.SessionID)
         if err != nil </span><span class="cov0" title="0">{
                 return nil, err
         }</span>
 
-        <span class="cov8" title="1">err = maker.redisClient.Set(ctx, tokenKey, "1", maker.config.RefreshToken.MaxLifetime).Err()
+        <span class="cov8" title="1">err = maker.redisClient.Set(ctx, tokenKey, "1", maker.config.RefreshMaxLifetimeExpiry).Err()
         if err != nil </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("failed to record rotation: %w", err)
         }</span>
@@ -1035,14 +1028,13 @@ func (maker *JWTMaker) RotateRefreshToken(ctx context.Context, oldToken string) 
         <span class="cov8" title="1">return newToken, nil</span>
 }
 
-// cleanupRotatedTokens runs as a background goroutine to remove expired rotated refresh tokens from Redis.
+// cleanupRotatedTokens periodically removes expired rotated token records from Redis.
 //
-// This is only started if RefreshToken.RotationEnabled is true. It uses SCAN to efficiently iterate over
-// all keys prefixed with "rotated:*" and checks their TTL. If any key has expired or has no remaining TTL,
-// it is queued for deletion. This helps avoid cluttering Redis with stale rotation entries.
+// This background goroutine runs hourly to clean up rotation tracking entries
+// that have exceeded their maximum lifetime. Prevents Redis memory bloat.
 //
-// Frequency: Every 1 hour.
-// Safety: Stops when context is canceled.
+// Parameters:
+//   - ctx: Context for cancellation
 func (maker *JWTMaker) cleanupRotatedTokens(ctx context.Context) <span class="cov8" title="1">{
         ticker := time.NewTicker(1 * time.Hour)
         defer ticker.Stop()
@@ -1097,14 +1089,13 @@ func (maker *JWTMaker) cleanupRotatedTokens(ctx context.Context) <span class="co
         }
 }
 
-// cleanupRevokedTokens removes expired revoked tokens from Redis to free memory.
+// cleanupRevokedTokens periodically removes expired revocation records from Redis.
 //
-// This method is launched as a goroutine only if token revocation is enabled for access or refresh tokens.
-// It scans all keys with prefixes "revoked:access:" and "revoked:refresh:", checks their TTLs,
-// and deletes expired ones in batches.
+// Similar to cleanupRotatedTokens but for revoked token entries.
+// Runs hourly in a background goroutine.
 //
-// Frequency: Every 1 hour.
-// This is a background housekeeping task to keep Redis clean from already-expired revocation entries.
+// Parameters:
+//   - ctx: Context for cancellation
 func (maker *JWTMaker) cleanupRevokedTokens(ctx context.Context) <span class="cov8" title="1">{
         ticker := time.NewTicker(1 * time.Hour)
         defer ticker.Stop()
@@ -1118,7 +1109,7 @@ func (maker *JWTMaker) cleanupRevokedTokens(ctx context.Context) <span class="co
                                 continue</span>
                         }
 
-                        <span class="cov0" title="0">for _, prefix := range []string{"revoked:access:", "revoked:refresh:"} </span><span class="cov0" title="0">{
+                        <span class="cov0" title="0">for _, prefix := range []string{revokedAccessPrefix, revokedRefreshPrefix} </span><span class="cov0" title="0">{
                                 var cursor uint64
                                 const batchSize = 100
 
@@ -1157,50 +1148,74 @@ func (maker *JWTMaker) cleanupRevokedTokens(ctx context.Context) <span class="co
         }
 }
 
-// initializeSigningMethod sets the JWT signing method instance based on the configured algorithm.
+// initializeSigningMethod configures the JWT signing algorithm based on the configuration.
 //
-// Supports HS256, RS256, ES256, PS256, EdDSA, and more.
-// Rejects "none" for security reasons. Returns error for unsupported algorithms.
+// Validates that the configured algorithm is supported and matches the signing method.
+// This is called during maker initialization.
+//
+// Returns:
+//   - error if the algorithm is invalid or unsupported
 func (maker *JWTMaker) initializeSigningMethod() error <span class="cov8" title="1">{
-        switch maker.config.Algorithm </span>{
+
+        // Check if configured algorithm is in allowed list if specified
+        if len(maker.config.AllowedAlgorithms) &gt; 0 </span><span class="cov8" title="1">{
+                allowed := false
+                for _, alg := range maker.config.AllowedAlgorithms </span><span class="cov8" title="1">{
+                        if alg == maker.config.Algorithm </span><span class="cov8" title="1">{
+                                allowed = true
+                                break</span>
+                        }
+                }
+                <span class="cov8" title="1">if !allowed </span><span class="cov8" title="1">{
+                        return fmt.Errorf("configured algorithm %s not in allowed algorithms list",
+                                maker.config.Algorithm)
+                }</span>
+        }
+
+        <span class="cov8" title="1">switch maker.config.Algorithm </span>{
         case "HS256":<span class="cov8" title="1">
                 maker.signingMethod = jwt.SigningMethodHS256</span>
-        case "HS384":<span class="cov8" title="1">
+        case "HS384":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodHS384</span>
-        case "HS512":<span class="cov8" title="1">
+        case "HS512":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodHS512</span>
         case "RS256":<span class="cov8" title="1">
                 maker.signingMethod = jwt.SigningMethodRS256</span>
-        case "RS384":<span class="cov8" title="1">
+        case "RS384":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodRS384</span>
-        case "RS512":<span class="cov8" title="1">
+        case "RS512":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodRS512</span>
         case "PS256":<span class="cov8" title="1">
                 maker.signingMethod = jwt.SigningMethodPS256</span>
-        case "PS384":<span class="cov8" title="1">
+        case "PS384":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodPS384</span>
-        case "PS512":<span class="cov8" title="1">
+        case "PS512":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodPS512</span>
         case "ES256":<span class="cov8" title="1">
                 maker.signingMethod = jwt.SigningMethodES256</span>
-        case "ES384":<span class="cov8" title="1">
+        case "ES384":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodES384</span>
-        case "ES512":<span class="cov8" title="1">
+        case "ES512":<span class="cov0" title="0">
                 maker.signingMethod = jwt.SigningMethodES512</span>
         case "EdDSA":<span class="cov8" title="1">
                 maker.signingMethod = jwt.SigningMethodEdDSA</span>
-        case "none":<span class="cov0" title="0">
+        case "none":<span class="cov8" title="1">
                 return fmt.Errorf("unsecured tokens are disabled for security reasons")</span>
-        default:<span class="cov0" title="0">
+        default:<span class="cov8" title="1">
                 return fmt.Errorf("unsupported algorithm: %s", maker.config.Algorithm)</span>
         }
+
         <span class="cov8" title="1">return nil</span>
 }
 
-// initializeKeys loads signing and verification keys based on the signing method.
+// initializeKeys loads and parses the cryptographic keys based on the configuration.
 //
-// For symmetric methods (HMAC), it uses the same key for both signing and verification.
-// For asymmetric methods (RSA, ECDSA, EdDSA), it reads and parses the keys from the specified file paths.
+// For symmetric signing, uses the configured secret key.
+// For asymmetric signing, loads and parses the key files.
+// This is called during maker initialization.
+//
+// Returns:
+//   - error if key loading or parsing fails
 func (maker *JWTMaker) initializeKeys() error <span class="cov8" title="1">{
         switch maker.config.SigningMethod </span>{
         case Symmetric:<span class="cov8" title="1">
@@ -1214,13 +1229,16 @@ func (maker *JWTMaker) initializeKeys() error <span class="cov8" title="1">{
         }
 }
 
-// parseKeyPair reads and parses the private/public key files based on the chosen asymmetric algorithm.
+// parseKeyPair loads and parses asymmetric key files.
 //
-// This function supports parsing RSA, ECDSA, and EdDSA keys from PEM-encoded files,
-// handling multiple formats (PKCS1, PKCS8, certificates). It returns descriptive errors if parsing fails.
+// Handles different key formats (PEM, PKCS8, etc.) for RSA, ECDSA, and EdDSA.
+// This is called during maker initialization when using asymmetric signing.
+//
+// Returns:
+//   - error if key parsing fails
 func (maker *JWTMaker) parseKeyPair() error <span class="cov8" title="1">{
         privateKeyBytes, err := os.ReadFile(maker.config.PrivateKeyPath)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return fmt.Errorf("failed to read private key file: %w", err)
         }</span>
 
@@ -1232,28 +1250,28 @@ func (maker *JWTMaker) parseKeyPair() error <span class="cov8" title="1">{
         <span class="cov8" title="1">switch maker.signingMethod.Alg() </span>{
         case "RS256", "RS384", "RS512", "PS256", "PS384", "PS512":<span class="cov8" title="1">
                 maker.privateKey, err = parseRSAPrivateKey(privateKeyBytes)
-                if err != nil </span><span class="cov0" title="0">{
+                if err != nil </span><span class="cov8" title="1">{
                         return fmt.Errorf("failed to parse RSA private key: %w", err)
                 }</span>
                 <span class="cov8" title="1">maker.publicKey, err = parseRSAPublicKey(publicKeyBytes)
                 if err != nil </span><span class="cov0" title="0">{
                         return fmt.Errorf("failed to parse RSA public key: %w", err)
                 }</span>
-        case "ES256", "ES384", "ES512":<span class="cov8" title="1">
+        case "ES256", "ES384", "ES512":<span class="cov0" title="0">
                 maker.privateKey, err = parseECDSAPrivateKey(privateKeyBytes)
                 if err != nil </span><span class="cov0" title="0">{
                         return fmt.Errorf("failed to parse ECDSA private key: %w", err)
                 }</span>
-                <span class="cov8" title="1">maker.publicKey, err = parseECDSAPublicKey(publicKeyBytes)
+                <span class="cov0" title="0">maker.publicKey, err = parseECDSAPublicKey(publicKeyBytes)
                 if err != nil </span><span class="cov0" title="0">{
                         return fmt.Errorf("failed to parse ECDSA public key: %w", err)
                 }</span>
         case "EdDSA":<span class="cov8" title="1">
                 maker.privateKey, err = parseEdDSAPrivateKey(privateKeyBytes)
-                if err != nil </span><span class="cov0" title="0">{
+                if err != nil </span><span class="cov8" title="1">{
                         return fmt.Errorf("failed to parse EdDSA private key: %w", err)
                 }</span>
-                <span class="cov8" title="1">maker.publicKey, err = parseEdDSAPublicKey(publicKeyBytes)
+                <span class="cov0" title="0">maker.publicKey, err = parseEdDSAPublicKey(publicKeyBytes)
                 if err != nil </span><span class="cov0" title="0">{
                         return fmt.Errorf("failed to parse EdDSA public key: %w", err)
                 }</span>
@@ -1264,15 +1282,23 @@ func (maker *JWTMaker) parseKeyPair() error <span class="cov8" title="1">{
         <span class="cov8" title="1">return nil</span>
 }
 
-// validateConfig performs a strict validation of the GourdianTokenConfig struct.
+// validateConfig checks all configuration parameters for validity.
 //
-// Ensures required fields are set for symmetric/asymmetric methods.
-// Checks for invalid or insecure combinations (e.g., using keys for the wrong signing method).
-// Also verifies file permissions of private/public key files to prevent leaking secrets.
+// Performs security checks like:
+// - Key size requirements
+// - Algorithm strength
+// - File permissions
+// - Logical duration relationships
+//
+// Parameters:
+//   - config: The configuration to validate
+//
+// Returns:
+//   - error if any configuration is invalid
 func validateConfig(config *GourdianTokenConfig) error <span class="cov8" title="1">{
         switch config.SigningMethod </span>{
         case Symmetric:<span class="cov8" title="1">
-                if config.SymmetricKey == "" </span><span class="cov8" title="1">{
+                if config.SymmetricKey == "" </span><span class="cov0" title="0">{
                         return fmt.Errorf("symmetric key is required for symmetric signing method")
                 }</span>
                 <span class="cov8" title="1">if !strings.HasPrefix(config.Algorithm, "HS") &amp;&amp; config.Algorithm != "none" </span><span class="cov8" title="1">{
@@ -1288,7 +1314,7 @@ func validateConfig(config *GourdianTokenConfig) error <span class="cov8" title=
                 if config.PrivateKeyPath == "" || config.PublicKeyPath == "" </span><span class="cov8" title="1">{
                         return fmt.Errorf("private and public key paths are required for asymmetric signing method")
                 }</span>
-                <span class="cov8" title="1">if config.SymmetricKey != "" </span><span class="cov0" title="0">{
+                <span class="cov8" title="1">if config.SymmetricKey != "" </span><span class="cov8" title="1">{
                         return fmt.Errorf("symmetric key must be empty for asymmetric signing")
                 }</span>
                 <span class="cov8" title="1">if !strings.HasPrefix(config.Algorithm, "RS") &amp;&amp;
@@ -1297,7 +1323,7 @@ func validateConfig(config *GourdianTokenConfig) error <span class="cov8" title=
                         config.Algorithm != "EdDSA" </span><span class="cov0" title="0">{
                         return fmt.Errorf("algorithm %s not compatible with asymmetric signing", config.Algorithm)
                 }</span>
-                <span class="cov8" title="1">if err := checkFilePermissions(config.PrivateKeyPath, 0644); err != nil </span><span class="cov8" title="1">{
+                <span class="cov8" title="1">if err := checkFilePermissions(config.PrivateKeyPath, 0644); err != nil </span><span class="cov0" title="0">{
                         return fmt.Errorf("insecure private key file permissions: %w", err)
                 }</span>
                 <span class="cov8" title="1">if err := checkFilePermissions(config.PublicKeyPath, 0644); err != nil </span><span class="cov0" title="0">{
@@ -1308,49 +1334,152 @@ func validateConfig(config *GourdianTokenConfig) error <span class="cov8" title=
                         config.SigningMethod, Symmetric, Asymmetric)</span>
         }
 
+        // Validate token durations make sense
+        <span class="cov8" title="1">if config.AccessExpiryDuration &lt;= 0 </span><span class="cov8" title="1">{
+                return fmt.Errorf("access token duration must be positive")
+        }</span>
+        <span class="cov8" title="1">if config.AccessMaxLifetimeExpiry &gt; 0 &amp;&amp;
+                config.AccessExpiryDuration &gt; config.AccessMaxLifetimeExpiry </span><span class="cov8" title="1">{
+                return fmt.Errorf("access token duration exceeds max lifetime")
+        }</span>
+
+        <span class="cov8" title="1">if config.RefreshExpiryDuration &lt;= 0 </span><span class="cov0" title="0">{
+                return fmt.Errorf("refresh token duration must be positive")
+        }</span>
+        <span class="cov8" title="1">if config.RefreshMaxLifetimeExpiry &gt; 0 &amp;&amp;
+                config.RefreshExpiryDuration &gt; config.RefreshMaxLifetimeExpiry </span><span class="cov0" title="0">{
+                return fmt.Errorf("refresh token duration exceeds max lifetime")
+        }</span>
+
+        <span class="cov8" title="1">if config.RefreshReuseInterval &lt; 0 </span><span class="cov0" title="0">{
+                return fmt.Errorf("refresh reuse interval cannot be negative")
+        }</span>
+
+        // Reject weak algorithms
+        <span class="cov8" title="1">weakAlgorithms := map[string]bool{
+                "HS256": false, // Considered strong enough with proper key size
+                "none":  true,
+        }
+        if weak, ok := weakAlgorithms[config.Algorithm]; ok &amp;&amp; weak </span><span class="cov0" title="0">{
+                return fmt.Errorf("algorithm %s is too weak for production use", config.Algorithm)
+        }</span>
+
+        <span class="cov8" title="1">if len(config.AllowedAlgorithms) &gt; 0 </span><span class="cov8" title="1">{
+                supportedAlgs := map[string]bool{
+                        "HS256": true, "HS384": true, "HS512": true,
+                        "RS256": true, "RS384": true, "RS512": true,
+                        "ES256": true, "ES384": true, "ES512": true,
+                        "PS256": true, "PS384": true, "PS512": true,
+                        "EdDSA": true,
+                }
+
+                for _, alg := range config.AllowedAlgorithms </span><span class="cov8" title="1">{
+                        if !supportedAlgs[alg] </span><span class="cov0" title="0">{
+                                return fmt.Errorf("unsupported algorithm in AllowedAlgorithms: %s", alg)
+                        }</span>
+                }
+        }
+
         <span class="cov8" title="1">return nil</span>
 }
 
-// toMapClaims converts strongly-typed claims (AccessTokenClaims or RefreshTokenClaims)
-// into jwt.MapClaims format used by the jwt-go library.
+// validateAlgorithmAndMethod ensures the algorithm matches the signing method.
 //
-// This internal helper panics if roles are empty or if the claims type is unsupported.
-// It ensures consistent token encoding.
+// For example, prevents using RSA algorithms with symmetric signing.
+// This is called during configuration validation.
+//
+// Parameters:
+//   - config: The configuration to validate
+//
+// Returns:
+//   - error if algorithm/method combination is invalid
+func validateAlgorithmAndMethod(config *GourdianTokenConfig) error <span class="cov8" title="1">{
+        switch config.SigningMethod </span>{
+        case Symmetric:<span class="cov8" title="1">
+                if !strings.HasPrefix(config.Algorithm, "HS") </span><span class="cov8" title="1">{
+                        return fmt.Errorf("algorithm %s not compatible with symmetric signing", config.Algorithm)
+                }</span>
+        case Asymmetric:<span class="cov8" title="1">
+                if !strings.HasPrefix(config.Algorithm, "RS") &amp;&amp;
+                        !strings.HasPrefix(config.Algorithm, "ES") &amp;&amp;
+                        !strings.HasPrefix(config.Algorithm, "PS") &amp;&amp;
+                        config.Algorithm != "EdDSA" </span><span class="cov8" title="1">{
+                        return fmt.Errorf("algorithm %s not compatible with asymmetric signing", config.Algorithm)
+                }</span>
+        }
+        <span class="cov8" title="1">return nil</span>
+}
+
+// toMapClaims converts structured claims to jwt.MapClaims for signing.
+//
+// Handles both AccessTokenClaims and RefreshTokenClaims, converting
+// all fields to the format expected by the JWT library.
+//
+// Parameters:
+//   - claims: Either AccessTokenClaims or RefreshTokenClaims
+//
+// Returns:
+//   - jwt.MapClaims ready for signing
 func toMapClaims(claims interface{}) jwt.MapClaims <span class="cov8" title="1">{
         switch v := claims.(type) </span>{
         case AccessTokenClaims:<span class="cov8" title="1">
                 if len(v.Roles) == 0 </span><span class="cov8" title="1">{
                         panic("at least one role must be provided")</span>
                 }
-                <span class="cov8" title="1">return jwt.MapClaims{
+                <span class="cov8" title="1">mapClaims := jwt.MapClaims{
                         "jti": v.ID.String(),
                         "sub": v.Subject.String(),
                         "usr": v.Username,
                         "sid": v.SessionID.String(),
+                        "iss": v.Issuer,
+                        "aud": v.Audience,
                         "iat": v.IssuedAt.Unix(),
                         "exp": v.ExpiresAt.Unix(),
                         "typ": string(v.TokenType),
                         "rls": v.Roles,
+                }
+                if !v.NotBefore.IsZero() </span><span class="cov8" title="1">{
+                        mapClaims["nbf"] = v.NotBefore.Unix()
                 }</span>
+                <span class="cov8" title="1">if !v.MaxLifetimeExpiry.IsZero() </span><span class="cov8" title="1">{
+                        mapClaims["mle"] = v.MaxLifetimeExpiry.Unix()
+                }</span>
+                <span class="cov8" title="1">return mapClaims</span>
         case RefreshTokenClaims:<span class="cov8" title="1">
-                return jwt.MapClaims{
+                mapClaims := jwt.MapClaims{
                         "jti": v.ID.String(),
                         "sub": v.Subject.String(),
                         "usr": v.Username,
                         "sid": v.SessionID.String(),
+                        "iss": v.Issuer,
+                        "aud": v.Audience,
                         "iat": v.IssuedAt.Unix(),
                         "exp": v.ExpiresAt.Unix(),
                         "typ": string(v.TokenType),
+                }
+                if !v.NotBefore.IsZero() </span><span class="cov8" title="1">{
+                        mapClaims["nbf"] = v.NotBefore.Unix()
                 }</span>
-        default:<span class="cov8" title="1">
+                <span class="cov8" title="1">if !v.MaxLifetimeExpiry.IsZero() </span><span class="cov8" title="1">{
+                        mapClaims["mle"] = v.MaxLifetimeExpiry.Unix()
+                }</span>
+                <span class="cov8" title="1">return mapClaims</span>
+        default:<span class="cov0" title="0">
                 panic(fmt.Sprintf("unsupported claims type: %T", claims))</span>
         }
 }
 
-// mapToAccessClaims decodes jwt.MapClaims into a strongly-typed AccessTokenClaims struct.
+// mapToAccessClaims converts JWT library claims back to AccessTokenClaims.
 //
-// It validates UUID formats, checks the existence and type of each claim,
-// and handles both []string and []interface{} formats for the "rls" (roles) claim.
+// Performs type checking and validation during conversion to ensure
+// all required fields are present and properly formatted.
+//
+// Parameters:
+//   - claims: Raw claims from JWT parsing
+//
+// Returns:
+//   - *AccessTokenClaims if valid
+//   - error if conversion fails
 func mapToAccessClaims(claims jwt.MapClaims) (*AccessTokenClaims, error) <span class="cov8" title="1">{
         // Validate and convert jti claim
         jti, ok := claims["jti"].(string)
@@ -1388,6 +1517,27 @@ func mapToAccessClaims(claims jwt.MapClaims) (*AccessTokenClaims, error) <span c
                 return nil, fmt.Errorf("invalid username type: expected string")
         }</span>
 
+        // Validate issuer claim
+        <span class="cov8" title="1">issuer, _ := claims["iss"].(string) // Optional
+
+        // Validate audience claim
+        var audience []string
+        if aud, ok := claims["aud"]; ok </span><span class="cov8" title="1">{
+                switch v := aud.(type) </span>{
+                case string:<span class="cov0" title="0">
+                        audience = []string{v}</span>
+                case []interface{}:<span class="cov8" title="1">
+                        audience = make([]string, 0, len(v))
+                        for _, a := range v </span><span class="cov8" title="1">{
+                                if aStr, ok := a.(string); ok </span><span class="cov8" title="1">{
+                                        audience = append(audience, aStr)
+                                }</span>
+                        }
+                case []string:<span class="cov8" title="1">
+                        audience = v</span>
+                }
+        }
+
         // Validate roles claim
         <span class="cov8" title="1">rolesInterface, ok := claims["rls"]
         if !ok </span><span class="cov0" title="0">{
@@ -1424,26 +1574,48 @@ func mapToAccessClaims(claims jwt.MapClaims) (*AccessTokenClaims, error) <span c
         // Get timestamps with validation
         <span class="cov8" title="1">iat := getUnixTime(claims["iat"])
         exp := getUnixTime(claims["exp"])
+        nbf := getUnixTime(claims["nbf"])
+        mle := getUnixTime(claims["mle"])
+
         if iat == 0 || exp == 0 </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid timestamp format")
         }</span>
 
-        <span class="cov8" title="1">return &amp;AccessTokenClaims{
+        <span class="cov8" title="1">accessClaims := &amp;AccessTokenClaims{
                 ID:        tokenID,
                 Subject:   userID,
                 Username:  username,
                 SessionID: sessionID,
+                Issuer:    issuer,
+                Audience:  audience,
                 IssuedAt:  time.Unix(iat, 0),
                 ExpiresAt: time.Unix(exp, 0),
                 TokenType: TokenType(typ),
                 Roles:     roles,
-        }, nil</span>
+        }
+
+        if nbf != 0 </span><span class="cov8" title="1">{
+                accessClaims.NotBefore = time.Unix(nbf, 0)
+        }</span>
+
+        // Only set MaxLifetimeExpiry if mle exists and is valid
+        <span class="cov8" title="1">if mle != 0 </span><span class="cov8" title="1">{
+                accessClaims.MaxLifetimeExpiry = time.Unix(mle, 0)
+        }</span>
+
+        <span class="cov8" title="1">return accessClaims, nil</span>
 }
 
-// mapToRefreshClaims decodes jwt.MapClaims into a strongly-typed RefreshTokenClaims struct.
+// mapToRefreshClaims converts JWT library claims back to RefreshTokenClaims.
 //
-// It ensures all fields exist and have correct types (UUIDs, timestamps, etc.),
-// and that the token type is specifically "refresh".
+// Similar to mapToAccessClaims but for refresh token specific claims.
+//
+// Parameters:
+//   - claims: Raw claims from JWT parsing
+//
+// Returns:
+//   - *RefreshTokenClaims if valid
+//   - error if conversion fails
 func mapToRefreshClaims(claims jwt.MapClaims) (*RefreshTokenClaims, error) <span class="cov8" title="1">{
         tokenID, err := uuid.Parse(claims["jti"].(string))
         if err != nil </span><span class="cov0" title="0">{
@@ -1465,6 +1637,25 @@ func mapToRefreshClaims(claims jwt.MapClaims) (*RefreshTokenClaims, error) <span
                 return nil, fmt.Errorf("invalid username type: expected string")
         }</span>
 
+        <span class="cov8" title="1">issuer, _ := claims["iss"].(string) // Optional
+
+        var audience []string
+        if aud, ok := claims["aud"]; ok </span><span class="cov8" title="1">{
+                switch v := aud.(type) </span>{
+                case string:<span class="cov0" title="0">
+                        audience = []string{v}</span>
+                case []interface{}:<span class="cov8" title="1">
+                        audience = make([]string, 0, len(v))
+                        for _, a := range v </span><span class="cov8" title="1">{
+                                if aStr, ok := a.(string); ok </span><span class="cov8" title="1">{
+                                        audience = append(audience, aStr)
+                                }</span>
+                        }
+                case []string:<span class="cov8" title="1">
+                        audience = v</span>
+                }
+        }
+
         <span class="cov8" title="1">typ, ok := claims["typ"].(string)
         if !ok </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid or missing token type")
@@ -1476,44 +1667,93 @@ func mapToRefreshClaims(claims jwt.MapClaims) (*RefreshTokenClaims, error) <span
 
         <span class="cov8" title="1">iat := getUnixTime(claims["iat"])
         exp := getUnixTime(claims["exp"])
+        nbf := getUnixTime(claims["nbf"])
+        mle := getUnixTime(claims["mle"])
 
         if iat == 0 || exp == 0 </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("invalid timestamp format")
         }</span>
 
-        <span class="cov8" title="1">return &amp;RefreshTokenClaims{
+        <span class="cov8" title="1">refreshClaims := &amp;RefreshTokenClaims{
                 ID:        tokenID,
                 Subject:   userID,
                 Username:  username,
                 SessionID: sessionID,
+                Issuer:    issuer,
+                Audience:  audience,
                 IssuedAt:  time.Unix(iat, 0),
                 ExpiresAt: time.Unix(exp, 0),
                 TokenType: TokenType(typ),
-        }, nil</span>
+        }
+
+        if nbf != 0 </span><span class="cov8" title="1">{
+                refreshClaims.NotBefore = time.Unix(nbf, 0)
+        }</span>
+
+        // Only set MaxLifetimeExpiry if mle exists and is valid
+        <span class="cov8" title="1">if mle != 0 </span><span class="cov8" title="1">{
+                refreshClaims.MaxLifetimeExpiry = time.Unix(mle, 0)
+        }</span>
+
+        <span class="cov8" title="1">return refreshClaims, nil</span>
 }
 
-// validateTokenClaims performs runtime validation of claims for expiration, issuance, and required fields.
+// validateTokenClaims checks all required claims are present and valid.
 //
-// It compares the "typ" claim to the expected type (access or refresh),
-// verifies timestamps, and ensures critical fields like jti, sub, sid, etc., are present.
-func validateTokenClaims(claims jwt.MapClaims, expectedType TokenType) error <span class="cov8" title="1">{
+// Implements claim validation logic including:
+// - Required claim presence
+// - Token type verification
+// - Timestamp validation
+// - UUID format checking
+//
+// Parameters:
+//   - claims: Raw claims to validate
+//   - expectedType: Either AccessToken or RefreshToken
+//   - required: List of required claim names
+//
+// Returns:
+//   - error if any validation fails
+func validateTokenClaims(claims jwt.MapClaims, expectedType TokenType, required []string) error <span class="cov8" title="1">{
+        // First validate required claims exist
+        baseRequired := map[TokenType][]string{
+                AccessToken:  {"jti", "sub", "sid", "usr", "iat", "exp", "typ", "rls"},
+                RefreshToken: {"jti", "sub", "sid", "usr", "iat", "exp", "typ"},
+        }
 
-        tokenType, ok := claims["typ"].(string)
-        if !ok || TokenType(tokenType) != expectedType </span><span class="cov8" title="1">{
-                return fmt.Errorf("invalid token type: expected %s", expectedType)
-        }</span>
-
-        <span class="cov8" title="1">requiredClaims := []string{"jti", "sub", "typ", "usr", "sid", "iat", "exp"}
-        if expectedType == AccessToken </span><span class="cov8" title="1">{
-                requiredClaims = append(requiredClaims, "rls")
-        }</span>
-
-        <span class="cov8" title="1">for _, claim := range requiredClaims </span><span class="cov8" title="1">{
+        // Check all required claims exist first
+        for _, claim := range append(baseRequired[expectedType], required...) </span><span class="cov8" title="1">{
                 if _, ok := claims[claim]; !ok </span><span class="cov8" title="1">{
                         return fmt.Errorf("missing required claim: %s", claim)
                 }</span>
         }
 
+        // Then validate individual claim formats
+        <span class="cov8" title="1">if jti, ok := claims["jti"].(string); !ok </span><span class="cov0" title="0">{
+                return fmt.Errorf("invalid token ID type: expected string")
+        }</span> else<span class="cov8" title="1"> if _, err := uuid.Parse(jti); err != nil </span><span class="cov8" title="1">{
+                return fmt.Errorf("invalid token ID format: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if sub, ok := claims["sub"].(string); !ok </span><span class="cov0" title="0">{
+                return fmt.Errorf("invalid user ID type: expected string")
+        }</span> else<span class="cov8" title="1"> if _, err := uuid.Parse(sub); err != nil </span><span class="cov8" title="1">{
+                return fmt.Errorf("invalid user ID format: %w", err)
+        }</span>
+
+        <span class="cov8" title="1">if sid, ok := claims["sid"].(string); !ok </span><span class="cov0" title="0">{
+                return fmt.Errorf("invalid session ID type: expected string")
+        }</span> else<span class="cov8" title="1"> if _, err := uuid.Parse(sid); err != nil </span><span class="cov8" title="1">{
+                return fmt.Errorf("invalid session ID format: %w", err)
+        }</span>
+
+        // Rest of the validation remains the same...
+        // Validate token type
+        <span class="cov8" title="1">tokenType, ok := claims["typ"].(string)
+        if !ok || TokenType(tokenType) != expectedType </span><span class="cov8" title="1">{
+                return fmt.Errorf("invalid token type: expected %s", expectedType)
+        }</span>
+
+        // Validate expiration
         <span class="cov8" title="1">exp, ok := claims["exp"].(float64)
         if !ok </span><span class="cov0" title="0">{
                 return fmt.Errorf("invalid exp claim type")
@@ -1522,15 +1762,34 @@ func validateTokenClaims(claims jwt.MapClaims, expectedType TokenType) error <sp
                 return fmt.Errorf("token has expired")
         }</span>
 
+        // Validate issuance time
         <span class="cov8" title="1">if iat, ok := claims["iat"].(float64); ok </span><span class="cov8" title="1">{
                 if time.Unix(int64(iat), 0).After(time.Now()) </span><span class="cov8" title="1">{
                         return fmt.Errorf("token issued in the future")
                 }</span>
         }
 
+        // Check max lifetime if present in claims
+        <span class="cov8" title="1">if mle, ok := claims["mle"].(float64); ok </span><span class="cov8" title="1">{
+                maxExpiry := time.Unix(int64(mle), 0)
+                if time.Now().After(maxExpiry) </span><span class="cov0" title="0">{
+                        return fmt.Errorf("token exceeded maximum lifetime")
+                }</span>
+        }
+
         <span class="cov8" title="1">return nil</span>
 }
 
+// parseEdDSAPrivateKey decodes an EdDSA private key from PEM format.
+//
+// Supports PKCS8 encoded private keys. Used when the signing algorithm is EdDSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded private key data
+//
+// Returns:
+//   - ed25519.PrivateKey if successful
+//   - error if parsing fails
 func parseEdDSAPrivateKey(pemBytes []byte) (ed25519.PrivateKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
         if block == nil </span><span class="cov0" title="0">{
@@ -1538,7 +1797,7 @@ func parseEdDSAPrivateKey(pemBytes []byte) (ed25519.PrivateKey, error) <span cla
         }</span>
 
         <span class="cov8" title="1">priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-        if err != nil </span><span class="cov0" title="0">{
+        if err != nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("failed to parse EdDSA private key: %w", err)
         }</span>
 
@@ -1550,6 +1809,16 @@ func parseEdDSAPrivateKey(pemBytes []byte) (ed25519.PrivateKey, error) <span cla
         <span class="cov8" title="1">return eddsaPriv, nil</span>
 }
 
+// parseEdDSAPublicKey decodes an EdDSA public key from PEM format.
+//
+// Supports both raw public keys and certificates. Used when the signing algorithm is EdDSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded public key or certificate
+//
+// Returns:
+//   - ed25519.PublicKey if successful
+//   - error if parsing fails
 func parseEdDSAPublicKey(pemBytes []byte) (ed25519.PublicKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
         if block == nil </span><span class="cov0" title="0">{
@@ -1576,9 +1845,19 @@ func parseEdDSAPublicKey(pemBytes []byte) (ed25519.PublicKey, error) <span class
         <span class="cov8" title="1">return eddsaPub, nil</span>
 }
 
+// parseRSAPrivateKey decodes an RSA private key from PEM format.
+//
+// Supports PKCS1 and PKCS8 encoded private keys. Used when the signing algorithm is RSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded private key data
+//
+// Returns:
+//   - *rsa.PrivateKey if successful
+//   - error if parsing fails
 func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
-        if block == nil </span><span class="cov0" title="0">{
+        if block == nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("failed to parse PEM block containing the RSA private key")
         }</span>
 
@@ -1618,6 +1897,16 @@ func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) <span class="c
         }, nil</span>
 }
 
+// parseRSAPublicKey decodes an RSA public key from PEM format.
+//
+// Supports PKIX, PKCS1, and certificate encoded public keys. Used when the signing algorithm is RSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded public key or certificate
+//
+// Returns:
+//   - *rsa.PublicKey if successful
+//   - error if parsing fails
 func parseRSAPublicKey(pemBytes []byte) (*rsa.PublicKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
         if block == nil </span><span class="cov0" title="0">{
@@ -1666,6 +1955,16 @@ func parseRSAPublicKey(pemBytes []byte) (*rsa.PublicKey, error) <span class="cov
         }, nil</span>
 }
 
+// parseECDSAPrivateKey decodes an ECDSA private key from PEM format.
+//
+// Supports SEC1 and PKCS8 encoded private keys. Used when the signing algorithm is ECDSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded private key data
+//
+// Returns:
+//   - *ecdsa.PrivateKey if successful
+//   - error if parsing fails
 func parseECDSAPrivateKey(pemBytes []byte) (*ecdsa.PrivateKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
         if block == nil </span><span class="cov0" title="0">{
@@ -1687,9 +1986,19 @@ func parseECDSAPrivateKey(pemBytes []byte) (*ecdsa.PrivateKey, error) <span clas
         <span class="cov8" title="1">return key, nil</span>
 }
 
+// parseECDSAPublicKey decodes an ECDSA public key from PEM format.
+//
+// Supports both raw public keys and certificates. Used when the signing algorithm is ECDSA.
+//
+// Parameters:
+//   - pemBytes: PEM encoded public key or certificate
+//
+// Returns:
+//   - *ecdsa.PublicKey if successful
+//   - error if parsing fails
 func parseECDSAPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) <span class="cov8" title="1">{
         block, _ := pem.Decode(pemBytes)
-        if block == nil </span><span class="cov0" title="0">{
+        if block == nil </span><span class="cov8" title="1">{
                 return nil, fmt.Errorf("failed to parse PEM block containing the ECDSA public key")
         }</span>
 
@@ -1706,13 +2015,23 @@ func parseECDSAPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) <span class=
                 <span class="cov0" title="0">return ecdsaPub, nil</span>
         }
 
-        <span class="cov8" title="1">ecdsaPub, ok := pub.(*ecdsa.PublicKey)
+        <span class="cov0" title="0">ecdsaPub, ok := pub.(*ecdsa.PublicKey)
         if !ok </span><span class="cov0" title="0">{
                 return nil, fmt.Errorf("not a valid ECDSA public key")
         }</span>
-        <span class="cov8" title="1">return ecdsaPub, nil</span>
+        <span class="cov0" title="0">return ecdsaPub, nil</span>
 }
 
+// checkFilePermissions verifies a file has secure permissions.
+//
+// Prevents key files from being world-readable. Used during configuration validation.
+//
+// Parameters:
+//   - path: File path to check
+//   - requiredPerm: Maximum allowed permissions (e.g., 0600)
+//
+// Returns:
+//   - error if permissions are too permissive
 func checkFilePermissions(path string, requiredPerm os.FileMode) error <span class="cov8" title="1">{
         info, err := os.Stat(path)
         if err != nil </span><span class="cov0" title="0">{
@@ -1727,15 +2046,25 @@ func checkFilePermissions(path string, requiredPerm os.FileMode) error <span cla
         <span class="cov8" title="1">return nil</span>
 }
 
+// getUnixTime extracts a Unix timestamp from various JWT claim formats.
+//
+// Handles different numeric types that JWT libraries might use for timestamp claims.
+//
+// Parameters:
+//   - claim: The claim value to convert
+//
+// Returns:
+//   - Unix timestamp if valid
+//   - 0 if conversion fails
 func getUnixTime(claim interface{}) int64 <span class="cov8" title="1">{
         switch v := claim.(type) </span>{
         case float64:<span class="cov8" title="1">
                 return int64(v)</span>
         case int64:<span class="cov8" title="1">
                 return v</span>
-        case int:<span class="cov0" title="0">
+        case int:<span class="cov8" title="1">
                 return int64(v)</span>
-        case json.Number:<span class="cov0" title="0">
+        case json.Number:<span class="cov8" title="1">
                 i, _ := v.Int64()
                 return i</span>
         default:<span class="cov8" title="1">
@@ -1743,12 +2072,18 @@ func getUnixTime(claim interface{}) int64 <span class="cov8" title="1">{
         }
 }
 
+// pkcs8 represents the structure of a PKCS8 private key.
+//
+// Used internally for parsing asymmetric private keys.
 type pkcs8 struct {
         Version    int
         Algo       pkix.AlgorithmIdentifier
         PrivateKey []byte
 }
 
+// rsaPrivateKey represents the structure of an RSA private key.
+//
+// Used internally for parsing RSA private keys.
 type rsaPrivateKey struct {
         Version int
         N       *big.Int

--- a/goReleaser.txt
+++ b/goReleaser.txt
@@ -1,3 +1,5 @@
+# File: goReleaser.txt
+
 logan@WarHammer ~/gourdiantoken (master)> make release
 git tag v1.0.1
 git push origin v1.0.1

--- a/gourdiantoken_claims_test.go
+++ b/gourdiantoken_claims_test.go
@@ -1,0 +1,120 @@
+// File: gourdiantoken_claims_test.go
+
+package gourdiantoken
+
+// import (
+// 	"testing"
+// 	"time"
+
+// 	"github.com/golang-jwt/jwt/v5"
+// 	"github.com/google/uuid"
+// 	"github.com/stretchr/testify/require"
+// )
+
+// func TestClaimsValidation(t *testing.T) {
+// 	now := time.Now()
+// 	validAccessClaims := jwt.MapClaims{
+// 		"jti": uuid.New().String(),
+// 		"sub": uuid.New().String(),
+// 		"usr": "testuser",
+// 		"sid": uuid.New().String(),
+// 		"iss": "test-issuer",
+// 		"aud": []string{"aud1", "aud2"},
+// 		"rls": []string{"admin", "user"},
+// 		"iat": now.Unix(),
+// 		"exp": now.Add(time.Hour).Unix(),
+// 		"nbf": now.Unix(),
+// 		"mle": now.Add(24 * time.Hour).Unix(),
+// 		"typ": string(AccessToken),
+// 	}
+
+// 	validRefreshClaims := jwt.MapClaims{
+// 		"jti": uuid.New().String(),
+// 		"sub": uuid.New().String(),
+// 		"usr": "testuser",
+// 		"sid": uuid.New().String(),
+// 		"iss": "test-issuer",
+// 		"aud": []string{"aud1", "aud2"},
+// 		"iat": now.Unix(),
+// 		"exp": now.Add(24 * time.Hour).Unix(),
+// 		"nbf": now.Unix(),
+// 		"mle": now.Add(7 * 24 * time.Hour).Unix(),
+// 		"typ": string(RefreshToken),
+// 	}
+
+// 	t.Run("Valid access token claims", func(t *testing.T) {
+// 		err := validateTokenClaims(validAccessClaims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.NoError(t, err)
+// 	})
+
+// 	t.Run("Valid refresh token claims", func(t *testing.T) {
+// 		err := validateTokenClaims(validRefreshClaims, RefreshToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.NoError(t, err)
+// 	})
+
+// 	t.Run("Missing required claim", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		delete(claims, "sub") // Remove required claim
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "missing required claim")
+// 	})
+
+// 	t.Run("Invalid token type", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		claims["typ"] = "invalid-type"
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "invalid token type")
+// 	})
+
+// 	t.Run("Expired token", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		claims["exp"] = now.Add(-time.Hour).Unix() // Expired
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "expired")
+// 	})
+
+// 	t.Run("Token from future", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		claims["iat"] = now.Add(time.Hour).Unix() // Future
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "future")
+// 	})
+
+// 	t.Run("Max lifetime exceeded", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		claims["mle"] = now.Add(-time.Hour).Unix() // Past
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "exceeded maximum lifetime")
+// 	})
+
+// 	t.Run("Invalid roles claim", func(t *testing.T) {
+// 		claims := jwt.MapClaims{}
+// 		for k, v := range validAccessClaims {
+// 			claims[k] = v
+// 		}
+// 		claims["rls"] = "not-an-array" // Invalid type
+// 		err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+// 		require.Error(t, err)
+// 		require.Contains(t, err.Error(), "invalid roles type")
+// 	})
+// }

--- a/gourdiantoken_concurrency_test.go
+++ b/gourdiantoken_concurrency_test.go
@@ -1,0 +1,82 @@
+// File: gourdiantoken_concurrency_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentTokenOperations(t *testing.T) {
+	maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, testRedisOptions())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	// Test concurrent token creation
+	t.Run("Concurrent Creation", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := maker.CreateAccessToken(context.Background(), userID, "user", []string{"admin"}, sessionID)
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+	})
+
+	// Test concurrent verification
+	t.Run("Concurrent Verification", func(t *testing.T) {
+		token, err := maker.CreateAccessToken(context.Background(), userID, "user", []string{"admin"}, sessionID)
+		require.NoError(t, err)
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := maker.VerifyAccessToken(context.Background(), token.Token)
+				require.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+	})
+
+	// In the concurrent rotation test, modify the maker creation to ensure fresh config
+	t.Run("Concurrent Rotation", func(t *testing.T) {
+		// Create a new maker with fresh config for this test
+		config := DefaultGourdianTokenConfig(testSymmetricKey)
+		config.RotationEnabled = true
+		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		require.NoError(t, err)
+
+		refreshToken, err := maker.CreateRefreshToken(context.Background(), userID, "user", sessionID)
+		require.NoError(t, err)
+
+		var successCount int
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, err := maker.RotateRefreshToken(context.Background(), refreshToken.Token)
+				if err == nil {
+					mu.Lock()
+					successCount++
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		require.Equal(t, 1, successCount, "only one rotation should succeed")
+	})
+}

--- a/gourdiantoken_config_test.go
+++ b/gourdiantoken_config_test.go
@@ -1,0 +1,108 @@
+// File: gourdiantoken_config_test.go
+
+package gourdiantoken
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidation(t *testing.T) {
+	t.Run("Valid symmetric config", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			Algorithm:                "HS256",
+			SigningMethod:            Symmetric,
+			SymmetricKey:             testSymmetricKey,
+			AccessExpiryDuration:     time.Hour,
+			RefreshExpiryDuration:    time.Hour * 24,
+			RefreshMaxLifetimeExpiry: time.Hour * 24 * 30,
+		}
+		err := validateConfig(&config)
+		require.NoError(t, err)
+	})
+
+	t.Run("Invalid symmetric key length", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			Algorithm:     "HS256",
+			SigningMethod: Symmetric,
+			SymmetricKey:  "too-short",
+		}
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "symmetric key must be at least 32 bytes")
+	})
+
+	t.Run("Valid asymmetric config", func(t *testing.T) {
+		// Generate temp RSA keys
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		privateBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		privateBlock := &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: privateBytes,
+		}
+
+		privatePath := filepath.Join(t.TempDir(), "private.pem")
+		err = os.WriteFile(privatePath, pem.EncodeToMemory(privateBlock), 0600)
+		require.NoError(t, err)
+
+		publicBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		publicBlock := &pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: publicBytes,
+		}
+
+		publicPath := filepath.Join(t.TempDir(), "public.pem")
+		err = os.WriteFile(publicPath, pem.EncodeToMemory(publicBlock), 0644)
+		require.NoError(t, err)
+
+		config := GourdianTokenConfig{
+			Algorithm:                "RS256",
+			SigningMethod:            Asymmetric,
+			PrivateKeyPath:           privatePath,
+			PublicKeyPath:            publicPath,
+			AccessExpiryDuration:     time.Hour,
+			RefreshExpiryDuration:    time.Hour * 24,
+			RefreshMaxLifetimeExpiry: time.Hour * 24 * 30,
+		}
+		err = validateConfig(&config)
+		require.NoError(t, err)
+	})
+
+	t.Run("Invalid expiry durations", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			Algorithm:                "HS256",
+			SigningMethod:            Symmetric,
+			SymmetricKey:             "test-secret-32-bytes-long-1234567890",
+			AccessExpiryDuration:     0,              // Invalid
+			RefreshExpiryDuration:    -1 * time.Hour, // Invalid
+			RefreshMaxLifetimeExpiry: time.Hour,
+		}
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "must be positive")
+	})
+
+	t.Run("Invalid max lifetime", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			Algorithm:               "HS256",
+			SigningMethod:           Symmetric,
+			SymmetricKey:            "test-secret-32-bytes-long-1234567890",
+			AccessExpiryDuration:    time.Hour * 2,
+			AccessMaxLifetimeExpiry: time.Hour, // Less than expiry duration
+		}
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max lifetime")
+	})
+}

--- a/gourdiantoken_init_test.go
+++ b/gourdiantoken_init_test.go
@@ -1,0 +1,146 @@
+// File: gourdiantoken_init_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeSigningMethod(t *testing.T) {
+	tests := []struct {
+		name      string
+		algorithm string
+		wantErr   bool
+	}{
+		{"HS256", "HS256", false},
+		{"RS256", "RS256", false},
+		{"ES256", "ES256", false},
+		{"PS256", "PS256", false},
+		{"EdDSA", "EdDSA", false},
+		{"Invalid", "INVALID", true},
+		{"None", "none", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maker := &JWTMaker{
+				config: GourdianTokenConfig{
+					Algorithm: tt.algorithm,
+				},
+			}
+			err := maker.initializeSigningMethod()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, maker.signingMethod)
+			}
+		})
+	}
+}
+
+func TestInitializeKeys(t *testing.T) {
+	t.Run("Symmetric key initialization", func(t *testing.T) {
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod: Symmetric,
+				SymmetricKey:  "test-secret-32-bytes-long-1234567890",
+			},
+			signingMethod: jwt.SigningMethodHS256,
+		}
+		err := maker.initializeKeys()
+		require.NoError(t, err)
+		require.NotNil(t, maker.privateKey)
+		require.NotNil(t, maker.publicKey)
+	})
+
+	t.Run("Asymmetric key initialization", func(t *testing.T) {
+		// Generate temp RSA keys
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		privateBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+		privateBlock := &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: privateBytes,
+		}
+
+		privatePath := filepath.Join(t.TempDir(), "private.pem")
+		err = os.WriteFile(privatePath, pem.EncodeToMemory(privateBlock), 0600)
+		require.NoError(t, err)
+
+		publicBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
+		require.NoError(t, err)
+		publicBlock := &pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: publicBytes,
+		}
+
+		publicPath := filepath.Join(t.TempDir(), "public.pem")
+		err = os.WriteFile(publicPath, pem.EncodeToMemory(publicBlock), 0644)
+		require.NoError(t, err)
+
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod:  Asymmetric,
+				Algorithm:      "RS256",
+				PrivateKeyPath: privatePath,
+				PublicKeyPath:  publicPath,
+			},
+			signingMethod: jwt.SigningMethodRS256,
+		}
+		err = maker.initializeKeys()
+		require.NoError(t, err)
+		require.NotNil(t, maker.privateKey)
+		require.NotNil(t, maker.publicKey)
+	})
+
+	t.Run("Invalid key paths", func(t *testing.T) {
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod:  Asymmetric,
+				Algorithm:      "RS256",
+				PrivateKeyPath: "nonexistent_private.pem",
+				PublicKeyPath:  "nonexistent_public.pem",
+			},
+			signingMethod: jwt.SigningMethodRS256,
+		}
+		err := maker.initializeKeys()
+		require.Error(t, err)
+	})
+}
+
+func TestNewGourdianTokenMaker(t *testing.T) {
+	t.Run("Successful creation with symmetric key", func(t *testing.T) {
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
+		require.NoError(t, err)
+		require.NotNil(t, maker)
+	})
+
+	t.Run("Failed creation with invalid config", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			SigningMethod: Symmetric,
+			SymmetricKey:  "too-short",
+		}
+		_, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Failed creation with cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := DefaultGourdianTokenMaker(ctx, testSymmetricKey, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	})
+}

--- a/gourdiantoken_integration_test.go
+++ b/gourdiantoken_integration_test.go
@@ -1,0 +1,260 @@
+// File: gourdiantoken_integration_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFullTokenLifecycle_Symmetric(t *testing.T) {
+	config := DefaultGourdianTokenConfig(testSymmetricKey)
+	config.RevocationEnabled = true
+	config.RotationEnabled = true
+
+	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+	require.NoError(t, err)
+
+	// Create test data
+	userID := uuid.New()
+	username := "testuser"
+	roles := []string{"admin", "user"}
+	sessionID := uuid.New()
+
+	// Step 1: Create access token
+	accessToken, err := maker.CreateAccessToken(context.Background(), userID, username, roles, sessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, accessToken.Token)
+
+	// Step 2: Verify access token
+	accessClaims, err := maker.VerifyAccessToken(context.Background(), accessToken.Token)
+	require.NoError(t, err)
+	require.Equal(t, userID, accessClaims.Subject)
+	require.Equal(t, username, accessClaims.Username)
+	require.Equal(t, sessionID, accessClaims.SessionID)
+	require.Equal(t, roles, accessClaims.Roles)
+
+	// Step 3: Create refresh token
+	refreshToken, err := maker.CreateRefreshToken(context.Background(), userID, username, sessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, refreshToken.Token)
+
+	// Step 4: Verify refresh token
+	refreshClaims, err := maker.VerifyRefreshToken(context.Background(), refreshToken.Token)
+	require.NoError(t, err)
+	require.Equal(t, userID, refreshClaims.Subject)
+	require.Equal(t, username, refreshClaims.Username)
+	require.Equal(t, sessionID, refreshClaims.SessionID)
+
+	// Step 5: Rotate refresh token
+	newRefreshToken, err := maker.RotateRefreshToken(context.Background(), refreshToken.Token)
+	require.NoError(t, err)
+	require.NotEmpty(t, newRefreshToken.Token)
+
+	// Step 6: Verify rotated refresh token can't be reused immediately
+	_, err = maker.RotateRefreshToken(context.Background(), refreshToken.Token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token reused too soon")
+
+	// Step 7: Revoke access token
+	err = maker.RevokeAccessToken(context.Background(), accessToken.Token)
+	require.NoError(t, err)
+
+	// Step 8: Verify revoked access token can't be used
+	_, err = maker.VerifyAccessToken(context.Background(), accessToken.Token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token has been revoked")
+
+	// Step 9: Create new access token with rotated refresh token
+	newAccessToken, err := maker.CreateAccessToken(context.Background(), userID, username, roles, sessionID)
+	require.NoError(t, err)
+
+	// Step 10: Verify new access token
+	_, err = maker.VerifyAccessToken(context.Background(), newAccessToken.Token)
+	require.NoError(t, err)
+}
+
+func TestFullTokenLifecycle_Asymmetric(t *testing.T) {
+	// Generate RSA key pair
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	privBytes := x509.MarshalPKCS1PrivateKey(privKey)
+	privBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes}
+	privPath := filepath.Join(t.TempDir(), "rsa.key")
+	require.NoError(t, os.WriteFile(privPath, pem.EncodeToMemory(privBlock), 0600))
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	require.NoError(t, err)
+	pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+	pubPath := filepath.Join(t.TempDir(), "rsa.pub")
+	require.NoError(t, os.WriteFile(pubPath, pem.EncodeToMemory(pubBlock), 0644))
+
+	config := GourdianTokenConfig{
+		SigningMethod:            Asymmetric,
+		Algorithm:                "RS256",
+		PrivateKeyPath:           privPath,
+		PublicKeyPath:            pubPath,
+		Issuer:                   "test-issuer",
+		Audience:                 []string{"test-audience"},
+		RotationEnabled:          true,
+		RevocationEnabled:        true,
+		AccessExpiryDuration:     30 * time.Minute,
+		AccessMaxLifetimeExpiry:  24 * time.Hour,
+		RefreshExpiryDuration:    7 * 24 * time.Hour,
+		RefreshMaxLifetimeExpiry: 30 * 24 * time.Hour,
+		RefreshReuseInterval:     5 * time.Minute,
+	}
+
+	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+	require.NoError(t, err)
+
+	// Create test data
+	userID := uuid.New()
+	username := "testuser"
+	roles := []string{"admin", "user"}
+	sessionID := uuid.New()
+
+	// Step 1: Create access token
+	accessToken, err := maker.CreateAccessToken(context.Background(), userID, username, roles, sessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, accessToken.Token)
+
+	// Step 2: Verify access token
+	accessClaims, err := maker.VerifyAccessToken(context.Background(), accessToken.Token)
+	require.NoError(t, err)
+	require.Equal(t, userID, accessClaims.Subject)
+	require.Equal(t, username, accessClaims.Username)
+	require.Equal(t, sessionID, accessClaims.SessionID)
+	require.Equal(t, roles, accessClaims.Roles)
+
+	// Step 3: Create refresh token
+	refreshToken, err := maker.CreateRefreshToken(context.Background(), userID, username, sessionID)
+	require.NoError(t, err)
+	require.NotEmpty(t, refreshToken.Token)
+
+	// Step 4: Verify refresh token
+	refreshClaims, err := maker.VerifyRefreshToken(context.Background(), refreshToken.Token)
+	require.NoError(t, err)
+	require.Equal(t, userID, refreshClaims.Subject)
+	require.Equal(t, username, refreshClaims.Username)
+	require.Equal(t, sessionID, refreshClaims.SessionID)
+
+	// Step 5: Rotate refresh token
+	newRefreshToken, err := maker.RotateRefreshToken(context.Background(), refreshToken.Token)
+	require.NoError(t, err)
+	require.NotEmpty(t, newRefreshToken.Token)
+
+	// Step 6: Verify rotated refresh token can't be reused immediately
+	_, err = maker.RotateRefreshToken(context.Background(), refreshToken.Token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token reused too soon")
+
+	// Step 7: Revoke access token
+	err = maker.RevokeAccessToken(context.Background(), accessToken.Token)
+	require.NoError(t, err)
+
+	// Step 8: Verify revoked access token can't be used
+	_, err = maker.VerifyAccessToken(context.Background(), accessToken.Token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token has been revoked")
+}
+
+// func TestMultipleKeyTypes(t *testing.T) {
+// 	tests := []struct {
+// 		name      string
+// 		algorithm string
+// 		keyGen    func() (privPath, pubPath string)
+// 	}{
+// 		{
+// 			name:      "RSA",
+// 			algorithm: "RS256",
+// 			keyGen: func() (string, string) {
+// 				privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+// 				privBytes := x509.MarshalPKCS1PrivateKey(privKey)
+// 				privBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes}
+// 				privPath := filepath.Join(t.TempDir(), "rsa.key")
+// 				require.NoError(t, os.WriteFile(privPath, pem.EncodeToMemory(privBlock), 0600))
+
+// 				pubBytes, _ := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+// 				pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+// 				pubPath := filepath.Join(t.TempDir(), "rsa.pub")
+// 				require.NoError(t, os.WriteFile(pubPath, pem.EncodeToMemory(pubBlock), 0644))
+// 				return privPath, pubPath
+// 			},
+// 		},
+// 		{
+// 			name:      "ECDSA",
+// 			algorithm: "ES256",
+// 			keyGen: func() (string, string) {
+// 				privKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+// 				privBytes, _ := x509.MarshalECPrivateKey(privKey)
+// 				privBlock := &pem.Block{Type: "EC PRIVATE KEY", Bytes: privBytes}
+// 				privPath := filepath.Join(t.TempDir(), "ec.key")
+// 				require.NoError(t, os.WriteFile(privPath, pem.EncodeToMemory(privBlock), 0600))
+
+// 				pubBytes, _ := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+// 				pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+// 				pubPath := filepath.Join(t.TempDir(), "ec.pub")
+// 				require.NoError(t, os.WriteFile(pubPath, pem.EncodeToMemory(pubBlock), 0644))
+// 				return privPath, pubPath
+// 			},
+// 		},
+// 		{
+// 			name:      "EdDSA",
+// 			algorithm: "EdDSA",
+// 			keyGen: func() (string, string) {
+// 				pubKey, privKey, _ := ed25519.GenerateKey(rand.Reader)
+// 				privBytes, _ := x509.MarshalPKCS8PrivateKey(privKey)
+// 				privBlock := &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}
+// 				privPath := filepath.Join(t.TempDir(), "ed.key")
+// 				require.NoError(t, os.WriteFile(privPath, pem.EncodeToMemory(privBlock), 0600))
+
+// 				pubBytes, _ := x509.MarshalPKIXPublicKey(pubKey)
+// 				pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+// 				pubPath := filepath.Join(t.TempDir(), "ed.pub")
+// 				require.NoError(t, os.WriteFile(pubPath, pem.EncodeToMemory(pubBlock), 0644))
+// 				return privPath, pubPath
+// 			},
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			privPath, pubPath := tt.keyGen()
+
+// 			config := GourdianTokenConfig{
+// 				SigningMethod:         Asymmetric,
+// 				Algorithm:             tt.algorithm,
+// 				PrivateKeyPath:        privPath,
+// 				PublicKeyPath:         pubPath,
+// 				Issuer:                "test-issuer",
+// 				Audience:              []string{"test-audience"},
+// 				AccessExpiryDuration:  30 * time.Minute,
+// 				RefreshExpiryDuration: 24 * time.Hour,
+// 			}
+
+// 			maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+// 			require.NoError(t, err)
+
+// 			// Test token creation and verification
+// 			userID := uuid.New()
+// 			accessToken, err := maker.CreateAccessToken(context.Background(), userID, "testuser", []string{"admin"}, uuid.New())
+// 			require.NoError(t, err)
+
+// 			claims, err := maker.VerifyAccessToken(context.Background(), accessToken.Token)
+// 			require.NoError(t, err)
+// 			require.Equal(t, userID, claims.Subject)
+// 		})
+// 	}
+// }

--- a/gourdiantoken_keyparsing_test.go
+++ b/gourdiantoken_keyparsing_test.go
@@ -1,0 +1,215 @@
+// File: gourdiantoken_keyparsing_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyParsingEdgeCases(t *testing.T) {
+	t.Run("Invalid PEM Block", func(t *testing.T) {
+		invalidPEM := []byte("-----BEGIN INVALID-----\ninvalid data\n-----END INVALID-----")
+		_, err := parseRSAPrivateKey(invalidPEM)
+		require.Error(t, err)
+	})
+
+	t.Run("Corrupted RSA Private Key", func(t *testing.T) {
+		// Generate a valid key first
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		// Marshal to PKCS1
+		privBytes := x509.MarshalPKCS1PrivateKey(privKey)
+
+		// Corrupt the key data
+		privBytes[10] ^= 0xFF // Flip some bits
+
+		block := &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: privBytes,
+		}
+
+		_, err = parseRSAPrivateKey(pem.EncodeToMemory(block))
+		require.Error(t, err)
+	})
+
+	t.Run("Ed25519 Key Parsing", func(t *testing.T) {
+		pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+
+		// Test private key parsing
+		privBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+		require.NoError(t, err)
+
+		privBlock := &pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: privBytes,
+		}
+
+		parsedPriv, err := parseEdDSAPrivateKey(pem.EncodeToMemory(privBlock))
+		require.NoError(t, err)
+		require.Equal(t, privKey, parsedPriv)
+
+		// Test public key parsing
+		pubBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+		require.NoError(t, err)
+
+		pubBlock := &pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: pubBytes,
+		}
+
+		parsedPub, err := parseEdDSAPublicKey(pem.EncodeToMemory(pubBlock))
+		require.NoError(t, err)
+		require.Equal(t, pubKey, parsedPub)
+	})
+
+	t.Run("Invalid EC Curve", func(t *testing.T) {
+		// Generate key with unsupported curve
+		privKey, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		require.NoError(t, err)
+
+		privBytes, err := x509.MarshalECPrivateKey(privKey)
+		require.NoError(t, err)
+
+		block := &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privBytes,
+		}
+
+		// Should still parse even though curve isn't typically used with JWT
+		_, err = parseECDSAPrivateKey(pem.EncodeToMemory(block))
+		require.NoError(t, err)
+	})
+
+	t.Run("File Permission Checks", func(t *testing.T) {
+		// Create a temp file with insecure permissions
+		tempFile := filepath.Join(t.TempDir(), "insecure.key")
+		err := os.WriteFile(tempFile, []byte("test data"), 0666)
+		require.NoError(t, err)
+
+		err = checkFilePermissions(tempFile, 0600)
+		require.Error(t, err)
+		// Check for any permission-related error, not exact message
+		require.Contains(t, err.Error(), "permissions")
+	})
+}
+
+func TestNewGourdianTokenMaker_InvalidConfigs(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  GourdianTokenConfig
+		wantErr bool
+	}{
+		{
+			name: "Invalid Algorithm",
+			config: GourdianTokenConfig{
+				SigningMethod: Symmetric,
+				Algorithm:     "INVALID",
+				SymmetricKey:  "12345678901234567890123456789012",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Asymmetric with missing keys",
+			config: GourdianTokenConfig{
+				SigningMethod: Asymmetric,
+				Algorithm:     "RS256",
+			},
+			wantErr: true,
+		},
+		// Add more invalid config cases
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewGourdianTokenMaker(context.Background(), tt.config, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewGourdianTokenMaker() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateAccessToken_InvalidInputs(t *testing.T) {
+	maker, _ := DefaultGourdianTokenMaker(context.Background(), "test-key-123456789012345678901234", nil)
+
+	tests := []struct {
+		name      string
+		userID    uuid.UUID
+		username  string
+		roles     []string
+		sessionID uuid.UUID
+		wantErr   bool
+	}{
+		{"Nil UserID", uuid.Nil, "user1", []string{"admin"}, uuid.New(), true},
+		{"Empty Roles", uuid.New(), "user1", []string{}, uuid.New(), true},
+		{"Long Username", uuid.New(), strings.Repeat("a", 1025), []string{"admin"}, uuid.New(), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := maker.CreateAccessToken(context.Background(), tt.userID, tt.username, tt.roles, tt.sessionID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateAccessToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRevocationFlow(t *testing.T) {
+	config := DefaultGourdianTokenConfig("test-key-123456789012345678901234")
+	config.RevocationEnabled = true
+
+	maker, _ := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+
+	// Create and verify token
+	token, _ := maker.CreateAccessToken(context.Background(), uuid.New(), "user1", []string{"admin"}, uuid.New())
+	_, err := maker.VerifyAccessToken(context.Background(), token.Token)
+	require.NoError(t, err)
+
+	// Revoke token
+	err = maker.RevokeAccessToken(context.Background(), token.Token)
+	require.NoError(t, err)
+
+	// Verify revoked token
+	_, err = maker.VerifyAccessToken(context.Background(), token.Token)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "revoked")
+}
+
+func TestKeyParsingErrors(t *testing.T) {
+	// Test invalid PEM data
+	_, err := parseRSAPrivateKey([]byte("not a pem"))
+	require.Error(t, err)
+
+	// Test invalid key type
+	_, err = parseECDSAPublicKey([]byte("-----BEGIN PUBLIC KEY-----\ninvalid\n-----END PUBLIC KEY-----"))
+	require.Error(t, err)
+}
+
+func TestInvalidConfig(t *testing.T) {
+	// Test invalid symmetric key length
+	cfg := DefaultGourdianTokenConfig("shortkey")
+	err := validateConfig(&cfg)
+	require.Error(t, err)
+
+	// Test asymmetric config without key paths
+	cfg = GourdianTokenConfig{SigningMethod: Asymmetric}
+	err = validateConfig(&cfg)
+	require.Error(t, err)
+}

--- a/gourdiantoken_response_test.go
+++ b/gourdiantoken_response_test.go
@@ -1,0 +1,110 @@
+// File: gourdiantoken_response_test.go
+
+package gourdiantoken
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseTypes(t *testing.T) {
+	now := time.Now()
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	t.Run("AccessTokenResponse JSON", func(t *testing.T) {
+		resp := AccessTokenResponse{
+			Token:             "test-token",
+			Subject:           userID,
+			SessionID:         sessionID,
+			Issuer:            "test-issuer",
+			Username:          "testuser",
+			Roles:             []string{"admin", "user"},
+			Audience:          []string{"aud1", "aud2"},
+			IssuedAt:          now,
+			ExpiresAt:         now.Add(time.Hour),
+			NotBefore:         now,
+			MaxLifetimeExpiry: now.Add(24 * time.Hour),
+			TokenType:         AccessToken,
+		}
+
+		// Test JSON marshaling
+		jsonData, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var decoded AccessTokenResponse
+		err = json.Unmarshal(jsonData, &decoded)
+		require.NoError(t, err)
+
+		require.Equal(t, resp.Token, decoded.Token)
+		require.Equal(t, resp.Subject, decoded.Subject)
+		require.Equal(t, resp.SessionID, decoded.SessionID)
+		require.Equal(t, resp.Issuer, decoded.Issuer)
+		require.Equal(t, resp.Username, decoded.Username)
+		require.Equal(t, resp.Roles, decoded.Roles)
+		require.Equal(t, resp.Audience, decoded.Audience)
+		require.Equal(t, resp.IssuedAt.Unix(), decoded.IssuedAt.Unix())
+		require.Equal(t, resp.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
+		require.Equal(t, resp.NotBefore.Unix(), decoded.NotBefore.Unix())
+		require.Equal(t, resp.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
+		require.Equal(t, resp.TokenType, decoded.TokenType)
+	})
+
+	t.Run("RefreshTokenResponse JSON", func(t *testing.T) {
+		resp := RefreshTokenResponse{
+			Token:             "test-token",
+			Subject:           userID,
+			SessionID:         sessionID,
+			Issuer:            "test-issuer",
+			Username:          "testuser",
+			Audience:          []string{"aud1", "aud2"},
+			IssuedAt:          now,
+			ExpiresAt:         now.Add(24 * time.Hour),
+			NotBefore:         now,
+			MaxLifetimeExpiry: now.Add(7 * 24 * time.Hour),
+			TokenType:         RefreshToken,
+		}
+
+		// Test JSON marshaling
+		jsonData, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		var decoded RefreshTokenResponse
+		err = json.Unmarshal(jsonData, &decoded)
+		require.NoError(t, err)
+
+		require.Equal(t, resp.Token, decoded.Token)
+		require.Equal(t, resp.Subject, decoded.Subject)
+		require.Equal(t, resp.SessionID, decoded.SessionID)
+		require.Equal(t, resp.Issuer, decoded.Issuer)
+		require.Equal(t, resp.Username, decoded.Username)
+		require.Equal(t, resp.Audience, decoded.Audience)
+		require.Equal(t, resp.IssuedAt.Unix(), decoded.IssuedAt.Unix())
+		require.Equal(t, resp.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
+		require.Equal(t, resp.NotBefore.Unix(), decoded.NotBefore.Unix())
+		require.Equal(t, resp.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
+		require.Equal(t, resp.TokenType, decoded.TokenType)
+	})
+
+	t.Run("Response validation", func(t *testing.T) {
+		t.Run("AccessTokenResponse with empty roles", func(t *testing.T) {
+			resp := AccessTokenResponse{
+				Roles: []string{},
+			}
+			_, err := json.Marshal(resp)
+			require.NoError(t, err) // Should not error, just empty array
+		})
+
+		t.Run("RefreshTokenResponse with empty username", func(t *testing.T) {
+			resp := RefreshTokenResponse{
+				Username: "",
+			}
+			_, err := json.Marshal(resp)
+			require.NoError(t, err) // Should not error, just empty string
+		})
+	})
+}

--- a/gourdiantoken_serialization_test.go
+++ b/gourdiantoken_serialization_test.go
@@ -1,4 +1,4 @@
-// gourdiantoken_serialization_test.go
+// File: gourdiantoken_serialization_test.go
 
 package gourdiantoken
 
@@ -16,14 +16,18 @@ func TestTokenClaimsSerialization(t *testing.T) {
 	t.Run("AccessTokenClaims", func(t *testing.T) {
 		now := time.Now().UTC()
 		claims := AccessTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "testuser",
-			SessionID: uuid.New(),
-			IssuedAt:  now,
-			ExpiresAt: now.Add(time.Hour),
-			TokenType: AccessToken,
-			Roles:     []string{"admin", "user"},
+			ID:                uuid.New(),
+			Subject:           uuid.New(),
+			Username:          "testuser",
+			SessionID:         uuid.New(),
+			Issuer:            "test-issuer",
+			Audience:          []string{"aud1", "aud2"},
+			Roles:             []string{"admin", "user"},
+			IssuedAt:          now,
+			ExpiresAt:         now.Add(time.Hour),
+			NotBefore:         now,
+			MaxLifetimeExpiry: now.Add(24 * time.Hour),
+			TokenType:         AccessToken,
 		}
 
 		// Test JSON serialization
@@ -39,8 +43,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject, decoded.Subject)
 			assert.Equal(t, claims.Username, decoded.Username)
 			assert.Equal(t, claims.SessionID, decoded.SessionID)
+			assert.Equal(t, claims.Issuer, decoded.Issuer)
+			assert.Equal(t, claims.Audience, decoded.Audience)
 			assert.Equal(t, claims.IssuedAt.Unix(), decoded.IssuedAt.Unix())
 			assert.Equal(t, claims.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
+			assert.Equal(t, claims.NotBefore.Unix(), decoded.NotBefore.Unix())
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
 			assert.Equal(t, claims.TokenType, decoded.TokenType)
 			assert.Equal(t, claims.Roles, decoded.Roles)
 		})
@@ -70,8 +78,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject.String(), mapClaims["sub"])
 			assert.Equal(t, claims.Username, mapClaims["usr"])
 			assert.Equal(t, claims.SessionID.String(), mapClaims["sid"])
+			assert.Equal(t, claims.Issuer, mapClaims["iss"])
+			assert.Equal(t, claims.Audience, mapClaims["aud"])
 			assert.Equal(t, claims.IssuedAt.Unix(), mapClaims["iat"])
 			assert.Equal(t, claims.ExpiresAt.Unix(), mapClaims["exp"])
+			assert.Equal(t, claims.NotBefore.Unix(), mapClaims["nbf"])
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), mapClaims["mle"])
 			assert.Equal(t, string(claims.TokenType), mapClaims["typ"])
 			assert.Equal(t, claims.Roles, mapClaims["rls"])
 		})
@@ -86,8 +98,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject, decodedClaims.Subject)
 			assert.Equal(t, claims.Username, decodedClaims.Username)
 			assert.Equal(t, claims.SessionID, decodedClaims.SessionID)
+			assert.Equal(t, claims.Issuer, decodedClaims.Issuer)
+			assert.Equal(t, claims.Audience, decodedClaims.Audience)
 			assert.Equal(t, claims.IssuedAt.Unix(), decodedClaims.IssuedAt.Unix())
 			assert.Equal(t, claims.ExpiresAt.Unix(), decodedClaims.ExpiresAt.Unix())
+			assert.Equal(t, claims.NotBefore.Unix(), decodedClaims.NotBefore.Unix())
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), decodedClaims.MaxLifetimeExpiry.Unix())
 			assert.Equal(t, claims.TokenType, decodedClaims.TokenType)
 			assert.Equal(t, claims.Roles, decodedClaims.Roles)
 		})
@@ -139,18 +155,30 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			_, err := mapToAccessClaims(mapClaims)
 			assert.Error(t, err)
 		})
+
+		// Test missing max lifetime expiry
+		t.Run("MapToAccessClaimsMissingMaxLifetime", func(t *testing.T) {
+			mapClaims := toMapClaims(claims)
+			delete(mapClaims, "mle")
+			_, err := mapToAccessClaims(mapClaims)
+			assert.NoError(t, err)
+		})
 	})
 
 	t.Run("RefreshTokenClaims", func(t *testing.T) {
 		now := time.Now().UTC()
 		claims := RefreshTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "testuser",
-			SessionID: uuid.New(),
-			IssuedAt:  now,
-			ExpiresAt: now.Add(24 * time.Hour),
-			TokenType: RefreshToken,
+			ID:                uuid.New(),
+			Subject:           uuid.New(),
+			Username:          "testuser",
+			SessionID:         uuid.New(),
+			Issuer:            "test-issuer",
+			Audience:          []string{"aud1", "aud2"},
+			IssuedAt:          now,
+			ExpiresAt:         now.Add(24 * time.Hour),
+			NotBefore:         now,
+			MaxLifetimeExpiry: now.Add(7 * 24 * time.Hour),
+			TokenType:         RefreshToken,
 		}
 
 		// Test JSON serialization
@@ -166,8 +194,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject, decoded.Subject)
 			assert.Equal(t, claims.Username, decoded.Username)
 			assert.Equal(t, claims.SessionID, decoded.SessionID)
+			assert.Equal(t, claims.Issuer, decoded.Issuer)
+			assert.Equal(t, claims.Audience, decoded.Audience)
 			assert.Equal(t, claims.IssuedAt.Unix(), decoded.IssuedAt.Unix())
 			assert.Equal(t, claims.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
+			assert.Equal(t, claims.NotBefore.Unix(), decoded.NotBefore.Unix())
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
 			assert.Equal(t, claims.TokenType, decoded.TokenType)
 		})
 
@@ -186,8 +218,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject.String(), mapClaims["sub"])
 			assert.Equal(t, claims.Username, mapClaims["usr"])
 			assert.Equal(t, claims.SessionID.String(), mapClaims["sid"])
+			assert.Equal(t, claims.Issuer, mapClaims["iss"])
+			assert.Equal(t, claims.Audience, mapClaims["aud"])
 			assert.Equal(t, claims.IssuedAt.Unix(), mapClaims["iat"])
 			assert.Equal(t, claims.ExpiresAt.Unix(), mapClaims["exp"])
+			assert.Equal(t, claims.NotBefore.Unix(), mapClaims["nbf"])
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), mapClaims["mle"])
 			assert.Equal(t, string(claims.TokenType), mapClaims["typ"])
 		})
 
@@ -201,8 +237,12 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, claims.Subject, decodedClaims.Subject)
 			assert.Equal(t, claims.Username, decodedClaims.Username)
 			assert.Equal(t, claims.SessionID, decodedClaims.SessionID)
+			assert.Equal(t, claims.Issuer, decodedClaims.Issuer)
+			assert.Equal(t, claims.Audience, decodedClaims.Audience)
 			assert.Equal(t, claims.IssuedAt.Unix(), decodedClaims.IssuedAt.Unix())
 			assert.Equal(t, claims.ExpiresAt.Unix(), decodedClaims.ExpiresAt.Unix())
+			assert.Equal(t, claims.NotBefore.Unix(), decodedClaims.NotBefore.Unix())
+			assert.Equal(t, claims.MaxLifetimeExpiry.Unix(), decodedClaims.MaxLifetimeExpiry.Unix())
 			assert.Equal(t, claims.TokenType, decodedClaims.TokenType)
 		})
 
@@ -237,6 +277,14 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			_, err := mapToRefreshClaims(mapClaims)
 			assert.Error(t, err)
 		})
+
+		// Test missing max lifetime expiry
+		t.Run("MapToRefreshClaimsMissingMaxLifetime", func(t *testing.T) {
+			mapClaims := toMapClaims(claims)
+			delete(mapClaims, "mle")
+			_, err := mapToRefreshClaims(mapClaims)
+			assert.NoError(t, err)
+		})
 	})
 
 	t.Run("ResponseTypes", func(t *testing.T) {
@@ -246,13 +294,18 @@ func TestTokenClaimsSerialization(t *testing.T) {
 
 		t.Run("AccessTokenResponse", func(t *testing.T) {
 			resp := AccessTokenResponse{
-				Token:     "test-token",
-				Subject:   userID,
-				Username:  "testuser",
-				SessionID: sessionID,
-				ExpiresAt: now.Add(time.Hour),
-				IssuedAt:  now,
-				Roles:     []string{"admin", "user"},
+				Token:             "test-token",
+				Subject:           userID,
+				Username:          "testuser",
+				SessionID:         sessionID,
+				Issuer:            "test-issuer",
+				Audience:          []string{"aud1", "aud2"},
+				Roles:             []string{"admin", "user"},
+				ExpiresAt:         now.Add(time.Hour),
+				IssuedAt:          now,
+				NotBefore:         now,
+				MaxLifetimeExpiry: now.Add(24 * time.Hour),
+				TokenType:         AccessToken,
 			}
 
 			// Test JSON serialization
@@ -267,19 +320,29 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, resp.Subject, decoded.Subject)
 			assert.Equal(t, resp.Username, decoded.Username)
 			assert.Equal(t, resp.SessionID, decoded.SessionID)
+			assert.Equal(t, resp.Issuer, decoded.Issuer)
+			assert.Equal(t, resp.Audience, decoded.Audience)
+			assert.Equal(t, resp.Roles, decoded.Roles)
 			assert.Equal(t, resp.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
 			assert.Equal(t, resp.IssuedAt.Unix(), decoded.IssuedAt.Unix())
-			assert.Equal(t, resp.Roles, decoded.Roles)
+			assert.Equal(t, resp.NotBefore.Unix(), decoded.NotBefore.Unix())
+			assert.Equal(t, resp.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
+			assert.Equal(t, resp.TokenType, decoded.TokenType)
 		})
 
 		t.Run("RefreshTokenResponse", func(t *testing.T) {
 			resp := RefreshTokenResponse{
-				Token:     "test-token",
-				Subject:   userID,
-				Username:  "testuser",
-				SessionID: sessionID,
-				ExpiresAt: now.Add(24 * time.Hour),
-				IssuedAt:  now,
+				Token:             "test-token",
+				Subject:           userID,
+				Username:          "testuser",
+				SessionID:         sessionID,
+				Issuer:            "test-issuer",
+				Audience:          []string{"aud1", "aud2"},
+				ExpiresAt:         now.Add(24 * time.Hour),
+				IssuedAt:          now,
+				NotBefore:         now,
+				MaxLifetimeExpiry: now.Add(7 * 24 * time.Hour),
+				TokenType:         RefreshToken,
 			}
 
 			// Test JSON serialization
@@ -294,8 +357,13 @@ func TestTokenClaimsSerialization(t *testing.T) {
 			assert.Equal(t, resp.Subject, decoded.Subject)
 			assert.Equal(t, resp.Username, decoded.Username)
 			assert.Equal(t, resp.SessionID, decoded.SessionID)
+			assert.Equal(t, resp.Issuer, decoded.Issuer)
+			assert.Equal(t, resp.Audience, decoded.Audience)
 			assert.Equal(t, resp.ExpiresAt.Unix(), decoded.ExpiresAt.Unix())
 			assert.Equal(t, resp.IssuedAt.Unix(), decoded.IssuedAt.Unix())
+			assert.Equal(t, resp.NotBefore.Unix(), decoded.NotBefore.Unix())
+			assert.Equal(t, resp.MaxLifetimeExpiry.Unix(), decoded.MaxLifetimeExpiry.Unix())
+			assert.Equal(t, resp.TokenType, decoded.TokenType)
 		})
 	})
 
@@ -336,6 +404,28 @@ func TestTokenClaimsSerialization(t *testing.T) {
 
 			// Should fail validation when converting to map claims
 			assert.Panics(t, func() {
+				toMapClaims(claims)
+			})
+		})
+
+		t.Run("MissingMaxLifetime", func(t *testing.T) {
+			claims := AccessTokenClaims{
+				ID:                uuid.New(),
+				Subject:           uuid.New(),
+				Username:          "testuser",
+				SessionID:         uuid.New(),
+				Issuer:            "test-issuer",
+				Audience:          []string{"aud1", "aud2"},
+				Roles:             []string{"admin"},
+				IssuedAt:          time.Now(),
+				ExpiresAt:         time.Now().Add(time.Hour),
+				NotBefore:         time.Now(),
+				MaxLifetimeExpiry: time.Time{}, // zero value
+				TokenType:         AccessToken,
+			}
+
+			// Should not panic with zero MaxLifetimeExpiry
+			assert.NotPanics(t, func() {
 				toMapClaims(claims)
 			})
 		})

--- a/gourdiantoken_test.go
+++ b/gourdiantoken_test.go
@@ -1,11 +1,10 @@
-// gourdiantoken_test.go
+// File: gourdiantoken_test.go
 
 package gourdiantoken
 
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -16,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,27 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-var (
-	testSymmetricKey = "test-secret-32-bytes-long-1234567890"
-)
-
-func testRedisOptions() *redis.Options {
-	return &redis.Options{
-		Addr:     "127.0.0.1:6379",
-		Password: "GourdianRedisSecret",
-		DB:       0,
-	}
-}
-
-func createTestMaker(t *testing.T, config GourdianTokenConfig) *JWTMaker {
-	t.Helper()
-
-	ctx := context.Background()
-	maker, err := NewGourdianTokenMaker(ctx, config, testRedisOptions())
-	require.NoError(t, err)
-	return maker.(*JWTMaker)
-}
 
 func redisTestClient(t *testing.T) *redis.Client {
 	client := redis.NewClient(testRedisOptions())
@@ -81,37 +58,6 @@ func generateTempRSAPair(t *testing.T) (privatePath, publicPath string) {
 	}
 
 	publicPath = filepath.Join(t.TempDir(), "public.pem")
-	err = os.WriteFile(publicPath, pem.EncodeToMemory(publicBlock), 0600)
-	require.NoError(t, err)
-
-	return privatePath, publicPath
-}
-
-func generateTempECDSAPair(t *testing.T) (privatePath, publicPath string) {
-	t.Helper()
-
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	privateBytes, err := x509.MarshalECPrivateKey(privateKey)
-	require.NoError(t, err)
-	privateBlock := &pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: privateBytes,
-	}
-
-	privatePath = filepath.Join(t.TempDir(), "ec_private.pem")
-	err = os.WriteFile(privatePath, pem.EncodeToMemory(privateBlock), 0600)
-	require.NoError(t, err)
-
-	publicBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
-	require.NoError(t, err)
-	publicBlock := &pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: publicBytes,
-	}
-
-	publicPath = filepath.Join(t.TempDir(), "ec_public.pem")
 	err = os.WriteFile(publicPath, pem.EncodeToMemory(publicBlock), 0600)
 	require.NoError(t, err)
 
@@ -156,44 +102,6 @@ func generateTempCertificate(t *testing.T) (privatePath, publicPath string) {
 	require.NoError(t, err)
 
 	return privatePath, publicPath
-}
-
-func generateTempEdDSAKeys(t *testing.T) (privateKeyPath, publicKeyPath string) {
-	t.Helper()
-
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-
-	// Create temp files
-	privateKeyFile, err := os.CreateTemp("", "ed25519-private-*.pem")
-	require.NoError(t, err)
-	defer privateKeyFile.Close()
-
-	publicKeyFile, err := os.CreateTemp("", "ed25519-public-*.pem")
-	require.NoError(t, err)
-	defer publicKeyFile.Close()
-
-	// Encode private key
-	privateKeyBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
-	require.NoError(t, err)
-	privateKeyBlock := &pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: privateKeyBytes,
-	}
-	err = pem.Encode(privateKeyFile, privateKeyBlock)
-	require.NoError(t, err)
-
-	// Encode public key
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
-	require.NoError(t, err)
-	publicKeyBlock := &pem.Block{
-		Type:  "PUBLIC KEY",
-		Bytes: publicKeyBytes,
-	}
-	err = pem.Encode(publicKeyFile, publicKeyBlock)
-	require.NoError(t, err)
-
-	return privateKeyFile.Name(), publicKeyFile.Name()
 }
 
 func generateRSAKey(bits int) *rsa.PrivateKey {
@@ -246,11 +154,9 @@ func writeTempKeyFiles(t testing.TB, key interface{}) (privatePath, publicPath s
 	return privatePath, publicPath
 }
 
-// TestTokenEdgeCases tests various edge cases in token creation and validation
 func TestTokenEdgeCases(t *testing.T) {
 	t.Run("Token with Empty UUID", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		emptyUUID := uuid.UUID{}
@@ -260,8 +166,7 @@ func TestTokenEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Token with Empty Roles", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		_, err = maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{}, uuid.New())
@@ -270,8 +175,7 @@ func TestTokenEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Token with Empty Role String", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		_, err = maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{""}, uuid.New())
@@ -280,8 +184,7 @@ func TestTokenEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Token with Very Long Username", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		longUsername := strings.Repeat("a", 1025)
@@ -291,7 +194,6 @@ func TestTokenEdgeCases(t *testing.T) {
 	})
 }
 
-// TestSecurityScenarios tests various security-related scenarios
 func TestSecurityScenarios(t *testing.T) {
 	t.Run("Algorithm Confusion Attack", func(t *testing.T) {
 		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -311,8 +213,7 @@ func TestSecurityScenarios(t *testing.T) {
 		rsaTokenString, err := rsaToken.SignedString(privateKey)
 		require.NoError(t, err)
 
-		hmacConfig := DefaultGourdianTokenConfig(testSymmetricKey)
-		hmacMaker, err := NewGourdianTokenMaker(context.Background(), hmacConfig, nil)
+		hmacMaker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		_, err = hmacMaker.VerifyAccessToken(context.Background(), rsaTokenString)
@@ -335,8 +236,7 @@ func TestSecurityScenarios(t *testing.T) {
 		tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 		require.NoError(t, err)
 
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
 		require.NoError(t, err)
 
 		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
@@ -346,11 +246,13 @@ func TestSecurityScenarios(t *testing.T) {
 
 	t.Run("Token Replay Attack", func(t *testing.T) {
 		client := redisTestClient(t)
-		defer client.Close()
+		defer func() {
+			if err := client.Close(); err != nil {
+				t.Errorf("failed to close redis client: %v", err)
+			}
+		}()
 
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.RevocationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, testRedisOptions())
 		require.NoError(t, err)
 
 		token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"role"}, uuid.New())
@@ -375,59 +277,23 @@ func TestSecurityScenarios(t *testing.T) {
 	})
 }
 
-// TestTokenRotation_ReuseInterval tests token rotation with reuse intervals
-func TestTokenRotation_ReuseInterval(t *testing.T) {
-	client := redisTestClient(t)
-	defer client.Close()
-
-	config := DefaultGourdianTokenConfig(testSymmetricKey)
-	config.RefreshToken.RotationEnabled = true
-	config.RefreshToken.ReuseInterval = time.Second
-	config.RefreshToken.MaxLifetime = time.Hour
-
-	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-	require.NoError(t, err)
-
-	token, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-	require.NoError(t, err)
-
-	// First rotation should work
-	_, err = maker.RotateRefreshToken(context.Background(), token.Token)
-	require.NoError(t, err)
-
-	// Immediate reuse should fail
-	_, err = maker.RotateRefreshToken(context.Background(), token.Token)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token reused too soon")
-
-	// Wait longer than reuse interval and try again
-	time.Sleep(2 * time.Second)
-	newToken, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-	require.NoError(t, err)
-
-	_, err = maker.RotateRefreshToken(context.Background(), newToken.Token)
-	require.NoError(t, err)
-}
-
-// TestCreateAndVerifyRefreshToken tests refresh token creation and verification
 func TestCreateAndVerifyRefreshToken(t *testing.T) {
 	// Setup symmetric maker
-	symmetricConfig := DefaultGourdianTokenConfig(testSymmetricKey)
-	symmetricMaker, err := NewGourdianTokenMaker(context.Background(), symmetricConfig, testRedisOptions())
+	symmetricMaker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, testRedisOptions())
 	require.NoError(t, err)
 
 	// Setup asymmetric maker
 	privatePath, publicPath := generateTempRSAPair(t)
 	asymmetricConfig := GourdianTokenConfig{
-		Algorithm:      "RS256",
-		SigningMethod:  Asymmetric,
-		PrivateKeyPath: privatePath,
-		PublicKeyPath:  publicPath,
-		RefreshToken: RefreshTokenConfig{
-			Duration:        24 * time.Hour,
-			MaxLifetime:     7 * 24 * time.Hour,
-			RotationEnabled: true,
-		},
+		Algorithm:                "RS256",
+		SigningMethod:            Asymmetric,
+		PrivateKeyPath:           privatePath,
+		PublicKeyPath:            publicPath,
+		RotationEnabled:          true,
+		AccessExpiryDuration:     time.Hour,
+		AccessMaxLifetimeExpiry:  24 * time.Hour,
+		RefreshExpiryDuration:    24 * time.Hour,
+		RefreshMaxLifetimeExpiry: 7 * 24 * time.Hour,
 	}
 	asymmetricMaker, err := NewGourdianTokenMaker(context.Background(), asymmetricConfig, testRedisOptions())
 	require.NoError(t, err)
@@ -483,7 +349,7 @@ func TestCreateAndVerifyRefreshToken(t *testing.T) {
 	t.Run("Invalid Token - Expired", func(t *testing.T) {
 		// Create a token with very short lifetime
 		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.Duration = time.Millisecond
+		config.RefreshExpiryDuration = time.Millisecond
 		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
 		require.NoError(t, err)
 
@@ -509,7 +375,6 @@ func TestCreateAndVerifyRefreshToken(t *testing.T) {
 	})
 }
 
-// TestKeyParsing tests various key parsing scenarios
 func TestKeyParsing(t *testing.T) {
 	t.Run("RSA PKCS8 Private Key", func(t *testing.T) {
 		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -596,110 +461,19 @@ func TestKeyParsing(t *testing.T) {
 	})
 }
 
-// TestTokenClaimsValidation tests various token claim validation scenarios
-func TestTokenClaimsValidation(t *testing.T) {
-	config := DefaultGourdianTokenConfig(testSymmetricKey)
-	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-	require.NoError(t, err)
-
-	t.Run("Missing Required Claim", func(t *testing.T) {
-		// Create a token missing the "sub" claim
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"jti": uuid.New().String(),
-			"usr": "testuser",
-			"sid": uuid.New().String(),
-			"iat": time.Now().Unix(),
-			"exp": time.Now().Add(time.Hour).Unix(),
-			"typ": AccessToken,
-			"rls": []string{"admin"},
-		})
-
-		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
-		require.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "missing required claim: sub")
-	})
-
-	t.Run("Invalid Token Type", func(t *testing.T) {
-		// Create a token with wrong type
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"jti": uuid.New().String(),
-			"sub": uuid.New().String(),
-			"usr": "testuser",
-			"sid": uuid.New().String(),
-			"iat": time.Now().Unix(),
-			"exp": time.Now().Add(time.Hour).Unix(),
-			"typ": "invalid",
-			"rls": []string{"admin"},
-		})
-
-		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
-		require.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token type")
-	})
-
-	t.Run("Token From Future", func(t *testing.T) {
-		// Create a token with iat in the future
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"jti": uuid.New().String(),
-			"sub": uuid.New().String(),
-			"usr": "testuser",
-			"sid": uuid.New().String(),
-			"iat": time.Now().Add(time.Hour).Unix(),
-			"exp": time.Now().Add(2 * time.Hour).Unix(),
-			"typ": AccessToken,
-			"rls": []string{"admin"},
-		})
-
-		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
-		require.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token issued in the future")
-	})
-
-	t.Run("Invalid Roles Claim", func(t *testing.T) {
-		// Create a token with invalid roles claim
-		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"jti": uuid.New().String(),
-			"sub": uuid.New().String(),
-			"usr": "testuser",
-			"sid": uuid.New().String(),
-			"iat": time.Now().Unix(),
-			"exp": time.Now().Add(time.Hour).Unix(),
-			"typ": AccessToken,
-			"rls": "not-an-array",
-		})
-
-		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
-		require.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid roles type")
-	})
-}
-
-// TestDefaultConfig tests the default configuration
 func TestDefaultConfig(t *testing.T) {
 	t.Run("Valid Default Config", func(t *testing.T) {
 		config := DefaultGourdianTokenConfig(testSymmetricKey)
 		assert.Equal(t, "HS256", config.Algorithm)
 		assert.Equal(t, Symmetric, config.SigningMethod)
-		assert.Equal(t, 30*time.Minute, config.AccessToken.Duration)
-		assert.Equal(t, 24*time.Hour, config.AccessToken.MaxLifetime)
-		assert.Equal(t, []string{"HS256"}, config.AccessToken.AllowedAlgorithms)
-		assert.Equal(t, []string{"jti", "sub", "exp", "iat", "typ", "rls"}, config.AccessToken.RequiredClaims)
-		assert.Equal(t, 7*24*time.Hour, config.RefreshToken.Duration)
-		assert.Equal(t, 30*24*time.Hour, config.RefreshToken.MaxLifetime)
-		assert.Equal(t, time.Minute, config.RefreshToken.ReuseInterval)
-		assert.False(t, config.RefreshToken.RotationEnabled)
+		assert.Equal(t, 30*time.Minute, config.AccessExpiryDuration)
+		assert.Equal(t, 24*time.Hour, config.AccessMaxLifetimeExpiry)
+		assert.Equal(t, []string{"HS256", "HS384", "HS512", "RS256", "ES256", "PS256"}, config.AllowedAlgorithms)
+		assert.Equal(t, []string{"iss", "aud", "nbf", "mle"}, config.RequiredClaims)
+		assert.Equal(t, 7*24*time.Hour, config.RefreshExpiryDuration)
+		assert.Equal(t, 30*24*time.Hour, config.RefreshMaxLifetimeExpiry)
+		assert.Equal(t, 5*time.Minute, config.RefreshReuseInterval)
+		assert.False(t, config.RotationEnabled)
 	})
 
 	t.Run("Invalid Key Length", func(t *testing.T) {
@@ -710,11 +484,10 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
-// TestTokenRotation_EdgeCases tests edge cases in token rotation
 func TestTokenRotation_EdgeCases(t *testing.T) {
 	t.Run("Rotation with Disabled Config", func(t *testing.T) {
 		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = false
+		config.RotationEnabled = false
 		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
 		require.NoError(t, err)
 
@@ -728,7 +501,7 @@ func TestTokenRotation_EdgeCases(t *testing.T) {
 
 	t.Run("Rotation with Invalid Token", func(t *testing.T) {
 		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
+		config.RotationEnabled = true
 		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
 		require.NoError(t, err)
 
@@ -739,8 +512,8 @@ func TestTokenRotation_EdgeCases(t *testing.T) {
 
 	t.Run("Rotation with Expired Token", func(t *testing.T) {
 		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		config.RefreshToken.Duration = time.Millisecond // Very short expiration
+		config.RotationEnabled = true
+		config.RefreshExpiryDuration = time.Millisecond // Very short expiration
 		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
 		require.NoError(t, err)
 
@@ -756,932 +529,148 @@ func TestTokenRotation_EdgeCases(t *testing.T) {
 	})
 }
 
-// TestConfigValidation tests configuration validation
-func TestConfigValidation(t *testing.T) {
-	t.Run("Valid Symmetric Config", func(t *testing.T) {
-		config := GourdianTokenConfig{
-			Algorithm:      "HS256",
-			SigningMethod:  Symmetric,
-			SymmetricKey:   testSymmetricKey,
-			PrivateKeyPath: "",
-			PublicKeyPath:  "",
-			AccessToken:    AccessTokenConfig{Duration: time.Hour},
-			RefreshToken:   RefreshTokenConfig{Duration: 24 * time.Hour},
-		}
-		err := validateConfig(&config)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Valid Asymmetric Config", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-		config := GourdianTokenConfig{
-			Algorithm:      "RS256",
-			SigningMethod:  Asymmetric,
-			SymmetricKey:   "",
-			PrivateKeyPath: privatePath,
-			PublicKeyPath:  publicPath,
-			AccessToken:    AccessTokenConfig{Duration: time.Hour},
-			RefreshToken:   RefreshTokenConfig{Duration: 24 * time.Hour},
-		}
-		err := validateConfig(&config)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Invalid Config - Mixed Key Configuration", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-		config := GourdianTokenConfig{
-			Algorithm:      "HS256",
-			SigningMethod:  Symmetric,
-			SymmetricKey:   testSymmetricKey,
-			PrivateKeyPath: privatePath, // This should cause validation to fail
-			PublicKeyPath:  publicPath,  // This should cause validation to fail
-			AccessToken: AccessTokenConfig{
-				Duration:    time.Hour,
-				MaxLifetime: 24 * time.Hour,
-			},
-		}
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private and public key paths must be empty for symmetric signing")
-	})
-
-	t.Run("Invalid Algorithm for Method", func(t *testing.T) {
-		config := GourdianTokenConfig{
-			Algorithm:     "RS256", // RSA algorithm
-			SigningMethod: Symmetric,
-			SymmetricKey:  testSymmetricKey,
-			AccessToken:   AccessTokenConfig{Duration: time.Hour},
-		}
-		err := validateConfig(&config)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "algorithm RS256 not compatible with symmetric signing")
-	})
-}
-
-// TestHelpers tests helper functions
-func TestHelpers(t *testing.T) {
-	t.Run("validateConfig", func(t *testing.T) {
-		t.Run("Valid Symmetric Config", func(t *testing.T) {
-			config := GourdianTokenConfig{
-				Algorithm:     "HS256",
-				SigningMethod: Symmetric,
-				SymmetricKey:  testSymmetricKey,
-				AccessToken:   AccessTokenConfig{Duration: time.Hour},
-			}
-			assert.NoError(t, validateConfig(&config))
-		})
-
-		t.Run("Invalid Symmetric Key Length", func(t *testing.T) {
-			config := GourdianTokenConfig{
-				Algorithm:     "HS256",
-				SigningMethod: Symmetric,
-				SymmetricKey:  "short",
-				AccessToken:   AccessTokenConfig{Duration: time.Hour},
-			}
-			assert.Error(t, validateConfig(&config))
-			assert.Contains(t, validateConfig(&config).Error(), "symmetric key must be at least 32 bytes")
-		})
-
-		t.Run("Valid Asymmetric Config", func(t *testing.T) {
-			privatePath, publicPath := generateTempRSAPair(t)
-			config := GourdianTokenConfig{
-				Algorithm:      "RS256",
-				SigningMethod:  Asymmetric,
-				PrivateKeyPath: privatePath,
-				PublicKeyPath:  publicPath,
-				AccessToken:    AccessTokenConfig{Duration: time.Hour},
-			}
-			assert.NoError(t, validateConfig(&config))
-		})
-
-		t.Run("Missing Key Paths", func(t *testing.T) {
-			config := GourdianTokenConfig{
-				Algorithm:     "RS256",
-				SigningMethod: Asymmetric,
-				AccessToken:   AccessTokenConfig{Duration: time.Hour},
-			}
-			assert.Error(t, validateConfig(&config))
-			assert.Contains(t, validateConfig(&config).Error(), "private and public key paths are required")
-		})
-	})
-
-	t.Run("toMapClaims", func(t *testing.T) {
-		now := time.Now()
-		accessClaims := AccessTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "testuser",
-			SessionID: uuid.New(),
-			IssuedAt:  now,
-			ExpiresAt: now.Add(time.Hour),
-			TokenType: AccessToken,
-			Roles:     []string{"admin"},
-		}
-
-		refreshClaims := RefreshTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "testuser",
-			SessionID: uuid.New(),
-			IssuedAt:  now,
-			ExpiresAt: now.Add(24 * time.Hour),
-			TokenType: RefreshToken,
-		}
-
-		t.Run("AccessTokenClaims", func(t *testing.T) {
-			claims := toMapClaims(accessClaims)
-			assert.Equal(t, accessClaims.ID.String(), claims["jti"])
-			assert.Equal(t, accessClaims.Subject.String(), claims["sub"])
-			assert.Equal(t, accessClaims.Username, claims["usr"])
-			assert.Equal(t, accessClaims.SessionID.String(), claims["sid"])
-			assert.Equal(t, accessClaims.IssuedAt.Unix(), claims["iat"])
-			assert.Equal(t, accessClaims.ExpiresAt.Unix(), claims["exp"])
-			assert.Equal(t, string(accessClaims.TokenType), claims["typ"])
-			assert.Equal(t, accessClaims.Roles, claims["rls"])
-		})
-
-		t.Run("RefreshTokenClaims", func(t *testing.T) {
-			claims := toMapClaims(refreshClaims)
-			assert.Equal(t, refreshClaims.ID.String(), claims["jti"])
-			assert.Equal(t, refreshClaims.Subject.String(), claims["sub"])
-			assert.Equal(t, refreshClaims.Username, claims["usr"])
-			assert.Equal(t, refreshClaims.SessionID.String(), claims["sid"])
-			assert.Equal(t, refreshClaims.IssuedAt.Unix(), claims["iat"])
-			assert.Equal(t, refreshClaims.ExpiresAt.Unix(), claims["exp"])
-			assert.Equal(t, string(refreshClaims.TokenType), claims["typ"])
-			assert.Nil(t, claims["rls"]) // Refresh tokens shouldn't have roles
-		})
-
-		t.Run("Invalid Type", func(t *testing.T) {
-			assert.Panics(t, func() {
-				toMapClaims("invalid type")
-			}, "should panic on unsupported claims type")
-		})
-
-	})
-}
-
-// TestRevocation tests token revocation functionality
-func TestRevocation(t *testing.T) {
+func TestTokenRotation_ReuseInterval(t *testing.T) {
 	client := redisTestClient(t)
-	defer client.Close()
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("failed to close redis client: %v", err)
+		}
+	}()
 
-	t.Run("Access Token Revocation", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.RevocationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"role"}, uuid.New())
-		require.NoError(t, err)
-
-		// Verify token works initially
-		_, err = maker.VerifyAccessToken(context.Background(), token.Token)
-		require.NoError(t, err)
-
-		// Revoke the token
-		err = maker.RevokeAccessToken(context.Background(), token.Token)
-		require.NoError(t, err)
-
-		// Verify token is now revoked
-		_, err = maker.VerifyAccessToken(context.Background(), token.Token)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token has been revoked")
-	})
-
-	t.Run("Refresh Token Revocation", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RevocationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		token, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-		require.NoError(t, err)
-
-		// Verify token works initially
-		_, err = maker.VerifyRefreshToken(context.Background(), token.Token)
-		require.NoError(t, err)
-
-		// Revoke the token
-		err = maker.RevokeRefreshToken(context.Background(), token.Token)
-		require.NoError(t, err)
-
-		// Verify token is now revoked
-		_, err = maker.VerifyRefreshToken(context.Background(), token.Token)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "token has been revoked")
-	})
-
-	t.Run("Revocation Not Enabled", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"role"}, uuid.New())
-		require.NoError(t, err)
-
-		err = maker.RevokeAccessToken(context.Background(), token.Token)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "access token revocation is not enabled")
-	})
-
-	t.Run("Revocation with Invalid Token", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.RevocationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		err = maker.RevokeAccessToken(context.Background(), "invalid.token.string")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token")
-	})
-}
-
-func TestTokenValidation(t *testing.T) {
-	ctx := context.Background()
 	config := DefaultGourdianTokenConfig(testSymmetricKey)
-	maker := createTestMaker(t, config)
+	config.RotationEnabled = true
+	config.RefreshReuseInterval = time.Second
+	// Ensure refresh duration is less than max lifetime
+	config.RefreshExpiryDuration = 30 * time.Minute
+	config.RefreshMaxLifetimeExpiry = time.Hour
 
-	t.Run("InvalidTokenType", func(t *testing.T) {
-		// Create an access token but claim it's a refresh token
-		claims := AccessTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "invalid-type",
-			SessionID: uuid.New(),
-			IssuedAt:  time.Now(),
-			ExpiresAt: time.Now().Add(time.Hour),
-			TokenType: RefreshToken, // Wrong type
-			Roles:     []string{"user"},
-		}
-
-		token := jwt.NewWithClaims(maker.signingMethod, toMapClaims(claims))
-		tokenString, err := token.SignedString(maker.privateKey)
-		assert.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(ctx, tokenString)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token type: expected access")
-	})
-
-	t.Run("FutureIssuedAt", func(t *testing.T) {
-		// Create a token with iat in the future
-		claims := AccessTokenClaims{
-			ID:        uuid.New(),
-			Subject:   uuid.New(),
-			Username:  "future-iat",
-			SessionID: uuid.New(),
-			IssuedAt:  time.Now().Add(time.Hour),
-			ExpiresAt: time.Now().Add(2 * time.Hour),
-			TokenType: AccessToken,
-			Roles:     []string{"user"},
-		}
-
-		token := jwt.NewWithClaims(maker.signingMethod, toMapClaims(claims))
-		tokenString, err := token.SignedString(maker.privateKey)
-		assert.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(ctx, tokenString)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token issued in the future")
-	})
-
-	t.Run("InvalidUUIDs", func(t *testing.T) {
-		// Create a token with invalid UUID strings
-		claims := jwt.MapClaims{
-			"jti": "not-a-uuid",
-			"sub": uuid.New().String(),
-			"usr": "invalid-uuid",
-			"sid": uuid.New().String(),
-			"iat": time.Now().Unix(),
-			"exp": time.Now().Add(time.Hour).Unix(),
-			"typ": string(AccessToken),
-			"rls": []string{"user"},
-		}
-
-		token := jwt.NewWithClaims(maker.signingMethod, claims)
-		tokenString, err := token.SignedString(maker.privateKey)
-		assert.NoError(t, err)
-
-		_, err = maker.VerifyAccessToken(ctx, tokenString)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token ID")
-	})
-}
-
-func TestTokenRevocation(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("AccessTokenRevocation", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.RevocationEnabled = true
-		maker := createTestMaker(t, config)
-
-		accessToken, err := maker.CreateAccessToken(ctx, uuid.New(), "revoke-test", []string{"user"}, uuid.New())
-		assert.NoError(t, err)
-
-		// Verify token works before revocation
-		_, err = maker.VerifyAccessToken(ctx, accessToken.Token)
-		assert.NoError(t, err)
-
-		// Revoke the token
-		err = maker.RevokeAccessToken(ctx, accessToken.Token)
-		assert.NoError(t, err)
-
-		// Verify token is now rejected
-		_, err = maker.VerifyAccessToken(ctx, accessToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token has been revoked")
-	})
-
-	t.Run("RefreshTokenRevocation", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RevocationEnabled = true
-		maker := createTestMaker(t, config)
-
-		refreshToken, err := maker.CreateRefreshToken(ctx, uuid.New(), "revoke-test", uuid.New())
-		assert.NoError(t, err)
-
-		// Verify token works before revocation
-		_, err = maker.VerifyRefreshToken(ctx, refreshToken.Token)
-		assert.NoError(t, err)
-
-		// Revoke the token
-		err = maker.RevokeRefreshToken(ctx, refreshToken.Token)
-		assert.NoError(t, err)
-
-		// Verify token is now rejected
-		_, err = maker.VerifyRefreshToken(ctx, refreshToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token has been revoked")
-	})
-
-	t.Run("RevocationDisabled", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.RevocationEnabled = false
-		maker := createTestMaker(t, config)
-
-		accessToken, err := maker.CreateAccessToken(ctx, uuid.New(), "revoke-test", []string{"user"}, uuid.New())
-		assert.NoError(t, err)
-
-		err = maker.RevokeAccessToken(ctx, accessToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "access token revocation is not enabled")
-	})
-}
-
-func TestRefreshTokenRotation(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("SuccessfulRotation", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		maker := createTestMaker(t, config)
-
-		userID := uuid.New()
-		sessionID := uuid.New()
-
-		// Create initial refresh token
-		oldToken, err := maker.CreateRefreshToken(ctx, userID, "rotation-test", sessionID)
-		assert.NoError(t, err)
-
-		// Rotate the token
-		newToken, err := maker.RotateRefreshToken(ctx, oldToken.Token)
-		assert.NoError(t, err)
-		assert.NotEqual(t, oldToken.Token, newToken.Token)
-		assert.Equal(t, userID, newToken.Subject)
-		assert.Equal(t, sessionID, newToken.SessionID)
-
-		// Verify the new token works
-		_, err = maker.VerifyRefreshToken(ctx, newToken.Token)
-		assert.NoError(t, err)
-
-		// Old token should be marked as rotated and rejected if used again
-		_, err = maker.RotateRefreshToken(ctx, oldToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token reused too soon")
-	})
-
-	t.Run("RotationDisabled", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = false
-		maker := createTestMaker(t, config)
-
-		refreshToken, err := maker.CreateRefreshToken(ctx, uuid.New(), "rotation-test", uuid.New())
-		assert.NoError(t, err)
-
-		_, err = maker.RotateRefreshToken(ctx, refreshToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token rotation not enabled")
-	})
-
-	t.Run("ReuseProtection", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		config.RefreshToken.ReuseInterval = time.Minute
-		maker := createTestMaker(t, config)
-
-		userID := uuid.New()
-		sessionID := uuid.New()
-
-		// Create and rotate token
-		oldToken, err := maker.CreateRefreshToken(ctx, userID, "reuse-test", sessionID)
-		assert.NoError(t, err)
-
-		_, err = maker.RotateRefreshToken(ctx, oldToken.Token)
-		assert.NoError(t, err)
-
-		// Immediate reuse attempt should fail
-		_, err = maker.RotateRefreshToken(ctx, oldToken.Token)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "token reused too soon")
-	})
-}
-
-func TestTokenMakerInitialization(t *testing.T) {
-	t.Run("DefaultSymmetricConfig", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker := createTestMaker(t, config)
-		assert.NotNil(t, maker)
-		assert.Equal(t, jwt.SigningMethodHS256, maker.signingMethod)
-	})
-
-	t.Run("SymmetricWithDifferentAlgorithms", func(t *testing.T) {
-		testCases := []struct {
-			algorithm string
-			method    jwt.SigningMethod
-		}{
-			{"HS256", jwt.SigningMethodHS256},
-			{"HS384", jwt.SigningMethodHS384},
-			{"HS512", jwt.SigningMethodHS512},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.algorithm, func(t *testing.T) {
-				config := DefaultGourdianTokenConfig(testSymmetricKey)
-				config.Algorithm = tc.algorithm
-				maker := createTestMaker(t, config)
-				assert.Equal(t, tc.method, maker.signingMethod)
-			})
-		}
-	})
-
-	t.Run("AsymmetricRSA", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-		defer os.Remove(privatePath)
-		defer os.Remove(publicPath)
-
-		testCases := []struct {
-			algorithm string
-			method    jwt.SigningMethod
-		}{
-			{"RS256", jwt.SigningMethodRS256},
-			{"RS384", jwt.SigningMethodRS384},
-			{"RS512", jwt.SigningMethodRS512},
-			{"PS256", jwt.SigningMethodPS256},
-			{"PS384", jwt.SigningMethodPS384},
-			{"PS512", jwt.SigningMethodPS512},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.algorithm, func(t *testing.T) {
-				config := DefaultGourdianTokenConfig("")
-				config.SigningMethod = Asymmetric
-				config.Algorithm = tc.algorithm
-				config.PrivateKeyPath = privatePath
-				config.PublicKeyPath = publicPath
-				maker := createTestMaker(t, config)
-				assert.Equal(t, tc.method, maker.signingMethod)
-				assert.IsType(t, &rsa.PrivateKey{}, maker.privateKey)
-				assert.IsType(t, &rsa.PublicKey{}, maker.publicKey)
-			})
-		}
-	})
-
-	t.Run("AsymmetricECDSA", func(t *testing.T) {
-		privatePath, publicPath := generateTempECDSAPair(t)
-		defer os.Remove(privatePath)
-		defer os.Remove(publicPath)
-
-		testCases := []struct {
-			algorithm string
-			method    jwt.SigningMethod
-		}{
-			{"ES256", jwt.SigningMethodES256},
-			{"ES384", jwt.SigningMethodES384},
-			{"ES512", jwt.SigningMethodES512},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.algorithm, func(t *testing.T) {
-				config := DefaultGourdianTokenConfig("")
-				config.SigningMethod = Asymmetric
-				config.Algorithm = tc.algorithm
-				config.PrivateKeyPath = privatePath
-				config.PublicKeyPath = publicPath
-				maker := createTestMaker(t, config)
-				assert.Equal(t, tc.method, maker.signingMethod)
-				assert.IsType(t, &ecdsa.PrivateKey{}, maker.privateKey)
-				assert.IsType(t, &ecdsa.PublicKey{}, maker.publicKey)
-			})
-		}
-	})
-
-	t.Run("AsymmetricEdDSA", func(t *testing.T) {
-		privatePath, publicPath := generateTempEdDSAKeys(t)
-		defer os.Remove(privatePath)
-		defer os.Remove(publicPath)
-
-		config := DefaultGourdianTokenConfig("")
-		config.SigningMethod = Asymmetric
-		config.Algorithm = "EdDSA"
-		config.PrivateKeyPath = privatePath
-		config.PublicKeyPath = publicPath
-		maker := createTestMaker(t, config)
-		assert.Equal(t, jwt.SigningMethodEdDSA, maker.signingMethod)
-		assert.IsType(t, ed25519.PrivateKey{}, maker.privateKey)
-		assert.IsType(t, ed25519.PublicKey{}, maker.publicKey)
-	})
-
-	t.Run("InvalidConfigurations", func(t *testing.T) {
-		testCases := []struct {
-			name        string
-			config      GourdianTokenConfig
-			expectedErr string
-		}{
-			{
-				name: "EmptySymmetricKey",
-				config: GourdianTokenConfig{
-					SigningMethod: Symmetric,
-					Algorithm:     "HS256",
-					SymmetricKey:  "",
-				},
-				expectedErr: "symmetric key is required",
-			},
-			{
-				name: "ShortSymmetricKey",
-				config: GourdianTokenConfig{
-					SigningMethod: Symmetric,
-					Algorithm:     "HS256",
-					SymmetricKey:  "too-short",
-				},
-				expectedErr: "symmetric key must be at least 32 bytes",
-			},
-			{
-				name: "AsymmetricMissingPrivateKey",
-				config: GourdianTokenConfig{
-					SigningMethod:  Asymmetric,
-					Algorithm:      "RS256",
-					PublicKeyPath:  "public.pem",
-					PrivateKeyPath: "",
-				},
-				expectedErr: "private and public key paths are required",
-			},
-			{
-				name: "UnsupportedAlgorithm",
-				config: GourdianTokenConfig{
-					SigningMethod: Symmetric,
-					Algorithm:     "UNSUPPORTED",
-					SymmetricKey:  testSymmetricKey,
-				},
-				expectedErr: "algorithm UNSUPPORTED not compatible with symmetric signing",
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				ctx := context.Background()
-				_, err := NewGourdianTokenMaker(ctx, tc.config, testRedisOptions())
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectedErr)
-			})
-		}
-	})
-}
-
-// TestCreateAndVerifyAccessToken tests access token creation and verification
-func TestCreateAndVerifyAccessToken(t *testing.T) {
-	// Setup symmetric maker
-	symmetricConfig := DefaultGourdianTokenConfig(testSymmetricKey)
-	symmetricMaker, err := NewGourdianTokenMaker(context.Background(), symmetricConfig, testRedisOptions())
+	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
 	require.NoError(t, err)
 
-	// Setup asymmetric maker
-	privatePath, publicPath := generateTempRSAPair(t)
-	asymmetricConfig := GourdianTokenConfig{
-		Algorithm:      "RS256",
-		SigningMethod:  Asymmetric,
-		PrivateKeyPath: privatePath,
-		PublicKeyPath:  publicPath,
-		AccessToken: AccessTokenConfig{
-			Duration:    time.Hour,
-			MaxLifetime: 24 * time.Hour,
-		},
-	}
-	asymmetricMaker, err := NewGourdianTokenMaker(context.Background(), asymmetricConfig, testRedisOptions())
+	token, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
 	require.NoError(t, err)
 
-	testCases := []struct {
-		name  string
-		maker GourdianTokenMaker
-	}{
-		{"Symmetric", symmetricMaker},
-		{"Asymmetric", asymmetricMaker},
+	// First rotation should work
+	_, err = maker.RotateRefreshToken(context.Background(), token.Token)
+	require.NoError(t, err)
+
+	// Immediate reuse should fail
+	_, err = maker.RotateRefreshToken(context.Background(), token.Token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token reused too soon")
+
+	// Wait longer than reuse interval and try again
+	time.Sleep(2 * time.Second)
+	newToken, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
+	require.NoError(t, err)
+
+	_, err = maker.RotateRefreshToken(context.Background(), newToken.Token)
+	require.NoError(t, err)
+}
+
+func TestTokenClaimsValidation(t *testing.T) {
+	config := DefaultGourdianTokenConfig(testSymmetricKey)
+	maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+	require.NoError(t, err)
+
+	// Common claims that satisfy all required claims
+	baseClaims := jwt.MapClaims{
+		"iss": config.Issuer,
+		"aud": config.Audience,
+		"nbf": time.Now().Unix(),
+		"mle": time.Now().Add(time.Hour).Unix(),
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			userID := uuid.New()
-			username := "testuser"
-			roles := []string{"admin"}
-			sessionID := uuid.New()
+	t.Run("Missing Required Claim", func(t *testing.T) {
+		claims := jwt.MapClaims{}
+		for k, v := range baseClaims {
+			claims[k] = v
+		}
+		claims["jti"] = uuid.New().String()
+		claims["usr"] = "testuser"
+		claims["sid"] = uuid.New().String()
+		claims["iat"] = time.Now().Unix()
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+		claims["typ"] = string(AccessToken)
+		claims["rls"] = []string{"admin"}
+		// Remove one required claim - now removing "sub" which is actually checked first
+		delete(claims, "sub")
 
-			// Test CreateAccessToken
-			resp, err := tc.maker.CreateAccessToken(context.Background(), userID, username, roles, sessionID)
-			require.NoError(t, err)
-			assert.NotEmpty(t, resp.Token)
-			assert.Equal(t, userID, resp.Subject)
-			assert.Equal(t, username, resp.Username)
-			assert.Equal(t, sessionID, resp.SessionID)
-			assert.Equal(t, roles, resp.Roles)
-			assert.True(t, time.Now().Before(resp.ExpiresAt))
-			assert.True(t, time.Now().After(resp.IssuedAt))
-
-			// Test VerifyAccessToken
-			claims, err := tc.maker.VerifyAccessToken(context.Background(), resp.Token)
-			require.NoError(t, err)
-			assert.Equal(t, userID, claims.Subject)
-			assert.Equal(t, username, claims.Username)
-			assert.Equal(t, sessionID, claims.SessionID)
-			assert.Equal(t, roles, claims.Roles)
-			assert.Equal(t, AccessToken, claims.TokenType)
-			assert.True(t, time.Now().Before(claims.ExpiresAt))
-			assert.True(t, time.Now().After(claims.IssuedAt))
-		})
-	}
-
-	t.Run("Invalid Token - Tampered", func(t *testing.T) {
-		resp, err := symmetricMaker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"role"}, uuid.New())
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
 		require.NoError(t, err)
 
-		// Tamper with the token
-		tamperedToken := resp.Token[:len(resp.Token)-4] + "abcd"
-
-		_, err = symmetricMaker.VerifyAccessToken(context.Background(), tamperedToken)
+		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid token")
+		assert.Contains(t, err.Error(), "missing required claim: sub")
 	})
 
-	t.Run("Invalid Token - Expired", func(t *testing.T) {
-		// Create a token with very short lifetime
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.AccessToken.Duration = time.Millisecond
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+	t.Run("Invalid Token Type", func(t *testing.T) {
+		claims := jwt.MapClaims{}
+		for k, v := range baseClaims {
+			claims[k] = v
+		}
+		claims["jti"] = uuid.New().String()
+		claims["sub"] = uuid.New().String()
+		claims["usr"] = "testuser"
+		claims["sid"] = uuid.New().String()
+		claims["iat"] = time.Now().Unix()
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+		claims["typ"] = "invalid" // Invalid type
+		claims["rls"] = []string{"admin"}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
 		require.NoError(t, err)
 
-		resp, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"role"}, uuid.New())
-		require.NoError(t, err)
-
-		// Wait for it to expire
-		time.Sleep(10 * time.Millisecond)
-
-		_, err = maker.VerifyAccessToken(context.Background(), resp.Token)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "expired")
-	})
-
-	t.Run("Invalid Token - Wrong Type", func(t *testing.T) {
-		// Create a refresh token but try to verify as access token
-		resp, err := symmetricMaker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-		require.NoError(t, err)
-
-		_, err = symmetricMaker.VerifyAccessToken(context.Background(), resp.Token)
+		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid token type")
 	})
-}
 
-// TestEnhancedTokenRotation tests advanced token rotation scenarios
-func TestEnhancedTokenRotation(t *testing.T) {
-	client := redisTestClient(t)
-	defer client.Close()
-
-	t.Run("Concurrent Rotation Attempts", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		config.RefreshToken.ReuseInterval = time.Second
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		token, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-		require.NoError(t, err)
-
-		var wg sync.WaitGroup
-		results := make(chan error, 10)
-
-		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				_, err := maker.RotateRefreshToken(context.Background(), token.Token)
-				results <- err
-			}()
+	t.Run("Token From Future", func(t *testing.T) {
+		claims := jwt.MapClaims{}
+		for k, v := range baseClaims {
+			claims[k] = v
 		}
+		claims["jti"] = uuid.New().String()
+		claims["sub"] = uuid.New().String()
+		claims["usr"] = "testuser"
+		claims["sid"] = uuid.New().String()
+		claims["iat"] = time.Now().Add(time.Hour).Unix() // Future iat
+		claims["exp"] = time.Now().Add(2 * time.Hour).Unix()
+		claims["typ"] = string(AccessToken)
+		claims["rls"] = []string{"admin"}
 
-		wg.Wait()
-		close(results)
-
-		var successCount, failureCount int
-		for err := range results {
-			if err == nil {
-				successCount++
-			} else {
-				failureCount++
-				assert.Contains(t, err.Error(), "token reused too soon")
-			}
-		}
-
-		require.Equal(t, 10, successCount+failureCount)
-		require.GreaterOrEqual(t, failureCount, 8)
-
-	})
-
-	t.Run("Rotation with Different Sessions", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
 		require.NoError(t, err)
 
-		userID := uuid.New()
-		session1 := uuid.New()
-		token1, err := maker.CreateRefreshToken(context.Background(), userID, "user", session1)
-		require.NoError(t, err)
-
-		session2 := uuid.New()
-		token2, err := maker.CreateRefreshToken(context.Background(), userID, "user", session2)
-		require.NoError(t, err)
-
-		_, err = maker.RotateRefreshToken(context.Background(), token1.Token)
-		require.NoError(t, err)
-
-		_, err = maker.RotateRefreshToken(context.Background(), token2.Token)
-		require.NoError(t, err)
-	})
-
-	t.Run("Rotation Chain", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-
-		// Create initial token
-		token, err := maker.CreateRefreshToken(context.Background(), uuid.New(), "user", uuid.New())
-		require.NoError(t, err)
-
-		// Rotate multiple times
-		for i := 0; i < 5; i++ {
-			token, err = maker.RotateRefreshToken(context.Background(), token.Token)
-			require.NoError(t, err)
-		}
-
-		// Verify the last rotated token
-		_, err = maker.VerifyRefreshToken(context.Background(), token.Token)
-		require.NoError(t, err)
-	})
-}
-
-// TestNewGourdianTokenMaker tests the token maker initialization
-func TestNewGourdianTokenMaker(t *testing.T) {
-	t.Run("Symmetric HS256", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-		assert.NotNil(t, maker)
-	})
-
-	t.Run("Asymmetric RSA", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-		config := GourdianTokenConfig{
-			Algorithm:      "RS256",
-			SigningMethod:  Asymmetric,
-			PrivateKeyPath: privatePath,
-			PublicKeyPath:  publicPath,
-			AccessToken: AccessTokenConfig{
-				Duration:    time.Hour,
-				MaxLifetime: 24 * time.Hour,
-			},
-		}
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-		assert.NotNil(t, maker)
-	})
-
-	t.Run("Asymmetric ECDSA", func(t *testing.T) {
-		privatePath, publicPath := generateTempECDSAPair(t)
-		config := GourdianTokenConfig{
-			Algorithm:      "ES256",
-			SigningMethod:  Asymmetric,
-			PrivateKeyPath: privatePath,
-			PublicKeyPath:  publicPath,
-			AccessToken: AccessTokenConfig{
-				Duration:    time.Hour,
-				MaxLifetime: 24 * time.Hour,
-			},
-		}
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.NoError(t, err)
-		assert.NotNil(t, maker)
-	})
-
-	t.Run("Invalid Config - Symmetric Key Too Short", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig("short")
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "symmetric key must be at least 32 bytes")
+		assert.Contains(t, err.Error(), "token issued in the future")
 	})
 
-	t.Run("Invalid Config - Missing Key Paths", func(t *testing.T) {
-		config := GourdianTokenConfig{
-			Algorithm:     "RS256",
-			SigningMethod: Asymmetric,
+	t.Run("Invalid Roles Claim", func(t *testing.T) {
+		claims := jwt.MapClaims{}
+		for k, v := range baseClaims {
+			claims[k] = v
 		}
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private and public key paths are required")
-	})
+		claims["jti"] = uuid.New().String()
+		claims["sub"] = uuid.New().String()
+		claims["usr"] = "testuser"
+		claims["sid"] = uuid.New().String()
+		claims["iat"] = time.Now().Unix()
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+		claims["typ"] = string(AccessToken)
+		claims["rls"] = "not-an-array" // Invalid roles type
 
-	t.Run("Invalid Config - Unsupported Algorithm", func(t *testing.T) {
-		config := GourdianTokenConfig{
-			Algorithm:     "FOO256",
-			SigningMethod: Symmetric,
-			SymmetricKey:  testSymmetricKey,
-		}
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not compatible with symmetric signing")
-	})
-
-	t.Run("Invalid Config - Insecure Key Permissions", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-
-		// Make the private key too permissive (world-writable)
-		require.NoError(t, os.Chmod(privatePath, 0777))
-
-		config := GourdianTokenConfig{
-			Algorithm:      "RS256",
-			SigningMethod:  Asymmetric,
-			PrivateKeyPath: privatePath,
-			PublicKeyPath:  publicPath,
-			AccessToken: AccessTokenConfig{
-				Duration:    time.Hour,
-				MaxLifetime: 24 * time.Hour,
-			},
-		}
-
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "insecure private key file permissions")
-	})
-
-	t.Run("Invalid Config - Mixed Key Configuration", func(t *testing.T) {
-		privatePath, publicPath := generateTempRSAPair(t)
-		config := GourdianTokenConfig{
-			Algorithm:      "HS256",
-			SigningMethod:  Symmetric,
-			SymmetricKey:   testSymmetricKey,
-			PrivateKeyPath: privatePath, // Should cause error for symmetric
-			PublicKeyPath:  publicPath,  // Should cause error for symmetric
-		}
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "private and public key paths must be empty for symmetric signing")
-	})
-
-	t.Run("Invalid Config - Algorithm/Signing Method Mismatch", func(t *testing.T) {
-		config := GourdianTokenConfig{
-			Algorithm:     "RS256", // RSA algorithm
-			SigningMethod: Symmetric,
-			SymmetricKey:  testSymmetricKey,
-		}
-		_, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "algorithm RS256 not compatible with symmetric signing")
-	})
-
-	t.Run("Rotation Enabled Without Redis", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		_, err := NewGourdianTokenMaker(context.Background(), config, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "redis options required for token rotation/revocation")
-	})
-
-	t.Run("Valid Rotation Configuration", func(t *testing.T) {
-		config := DefaultGourdianTokenConfig(testSymmetricKey)
-		config.RefreshToken.RotationEnabled = true
-		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		tokenString, err := token.SignedString([]byte(config.SymmetricKey))
 		require.NoError(t, err)
-		assert.NotNil(t, maker)
-		assert.NotNil(t, maker.(*JWTMaker).redisClient)
+
+		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid roles type")
 	})
 }

--- a/gourdiantoken_validation_test.go
+++ b/gourdiantoken_validation_test.go
@@ -1,0 +1,304 @@
+// File: gourdiantoken_validation_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeSigningMethod_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		algorithm   string
+		allowedAlgs []string
+		expectedErr string
+	}{
+		{
+			name:        "Unsupported algorithm",
+			algorithm:   "INVALID",
+			expectedErr: "unsupported algorithm",
+		},
+		{
+			name:        "Algorithm not in allowed list",
+			algorithm:   "HS384",
+			allowedAlgs: []string{"HS256", "RS256"},
+			expectedErr: "configured algorithm HS384 not in allowed algorithms list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			maker := &JWTMaker{
+				config: GourdianTokenConfig{
+					Algorithm:         tt.algorithm,
+					AllowedAlgorithms: tt.allowedAlgs,
+				},
+			}
+
+			err := maker.initializeSigningMethod()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestTokenCreationEdgeCases(t *testing.T) {
+	maker, err := DefaultGourdianTokenMaker(context.Background(), testSymmetricKey, nil)
+	require.NoError(t, err)
+
+	t.Run("Create Access Token with Empty Roles", func(t *testing.T) {
+		_, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{}, uuid.New())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one role must be provided")
+	})
+
+	t.Run("Create Access Token with Empty Role String", func(t *testing.T) {
+		_, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{""}, uuid.New())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "roles cannot contain empty strings")
+	})
+
+	t.Run("Create Refresh Token with Long Username", func(t *testing.T) {
+		longUsername := strings.Repeat("a", 1025)
+		_, err := maker.CreateRefreshToken(context.Background(), uuid.New(), longUsername, uuid.New())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "username too long")
+	})
+}
+
+func TestInitializeKeys_EdgeCases(t *testing.T) {
+	t.Run("Invalid Symmetric Key Length", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			SigningMethod: Symmetric,
+			SymmetricKey:  "too-short",
+			Algorithm:     "HS256",
+		}
+
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "symmetric key must be at least 32 bytes")
+
+		maker := &JWTMaker{
+			config:        config,
+			signingMethod: jwt.SigningMethodHS256,
+		}
+		err = maker.initializeKeys()
+		require.NoError(t, err) // initializeKeys assumes config is valid
+	})
+
+	t.Run("Missing Private Key File", func(t *testing.T) {
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod:  Asymmetric,
+				Algorithm:      "RS256",
+				PrivateKeyPath: "nonexistent.key",
+				PublicKeyPath:  "nonexistent.pub",
+			},
+			signingMethod: jwt.SigningMethodRS256,
+		}
+
+		err := maker.initializeKeys()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read private key file")
+	})
+
+	t.Run("Invalid Private Key Format", func(t *testing.T) {
+		tempDir := t.TempDir()
+		invalidKeyPath := filepath.Join(tempDir, "invalid.key")
+		require.NoError(t, os.WriteFile(invalidKeyPath, []byte("invalid key data"), 0600))
+
+		// Create dummy public key file
+		pubKeyPath := filepath.Join(tempDir, "public.pub")
+		require.NoError(t, os.WriteFile(pubKeyPath, []byte("dummy public key"), 0644))
+
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod:  Asymmetric,
+				Algorithm:      "RS256",
+				PrivateKeyPath: invalidKeyPath,
+				PublicKeyPath:  pubKeyPath,
+			},
+			signingMethod: jwt.SigningMethodRS256,
+		}
+
+		err := maker.initializeKeys()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse RSA private key")
+	})
+
+	t.Run("Key Algorithm Mismatch", func(t *testing.T) {
+		// Generate RSA key but try to use with EdDSA algorithm
+		privKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		privBytes := x509.MarshalPKCS1PrivateKey(privKey)
+		privBlock := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: privBytes}
+		privPath := filepath.Join(t.TempDir(), "rsa.key")
+		require.NoError(t, os.WriteFile(privPath, pem.EncodeToMemory(privBlock), 0600))
+
+		// Generate Ed25519 public key
+		pubKey, _, _ := ed25519.GenerateKey(rand.Reader)
+		pubBytes, _ := x509.MarshalPKIXPublicKey(pubKey)
+		pubBlock := &pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}
+		pubPath := filepath.Join(t.TempDir(), "ed25519.pub")
+		require.NoError(t, os.WriteFile(pubPath, pem.EncodeToMemory(pubBlock), 0644))
+
+		maker := &JWTMaker{
+			config: GourdianTokenConfig{
+				SigningMethod:  Asymmetric,
+				Algorithm:      "EdDSA",
+				PrivateKeyPath: privPath,
+				PublicKeyPath:  pubPath,
+			},
+			signingMethod: jwt.SigningMethodEdDSA,
+		}
+
+		err := maker.initializeKeys()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse EdDSA private key")
+	})
+}
+
+func TestValidateConfig_EdgeCases(t *testing.T) {
+	t.Run("Invalid Symmetric Config with Key Paths", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			SigningMethod:     Symmetric,
+			SymmetricKey:      testSymmetricKey,
+			PrivateKeyPath:    "private.key",
+			PublicKeyPath:     "public.key",
+			Algorithm:         "HS256",
+			AllowedAlgorithms: []string{"HS256"},
+		}
+
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "private and public key paths must be empty for symmetric signing")
+	})
+
+	t.Run("Invalid Asymmetric Config with Symmetric Key", func(t *testing.T) {
+		config := GourdianTokenConfig{
+			SigningMethod:     Asymmetric,
+			SymmetricKey:      testSymmetricKey,
+			PrivateKeyPath:    "private.key", // Add these to trigger the correct error
+			PublicKeyPath:     "public.key",
+			Algorithm:         "RS256",
+			AllowedAlgorithms: []string{"RS256"},
+		}
+
+		err := validateConfig(&config)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "symmetric key must be empty for asymmetric signing")
+	})
+
+	t.Run("Invalid Expiry Durations", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			accessExpiry  time.Duration
+			refreshExpiry time.Duration
+			expectedErr   string
+		}{
+			{
+				name:          "Negative access expiry",
+				accessExpiry:  -time.Hour,
+				refreshExpiry: time.Hour,
+				expectedErr:   "access token duration must be positive",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				config := GourdianTokenConfig{
+					SigningMethod:           Symmetric,
+					SymmetricKey:            testSymmetricKey,
+					Algorithm:               "HS256",
+					AccessExpiryDuration:    tt.accessExpiry,
+					AccessMaxLifetimeExpiry: 24 * time.Hour,
+					RefreshExpiryDuration:   tt.refreshExpiry,
+				}
+
+				err := validateConfig(&config)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
+			})
+		}
+	})
+}
+
+func TestValidateTokenClaims_EdgeCases(t *testing.T) {
+	now := time.Now()
+	validClaims := jwt.MapClaims{
+		"jti": uuid.New().String(),
+		"sub": uuid.New().String(),
+		"usr": "testuser",
+		"sid": uuid.New().String(),
+		"iss": "test-issuer",
+		"aud": []string{"aud1", "aud2"},
+		"rls": []string{"admin"},
+		"iat": now.Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+		"nbf": now.Unix(),
+		"mle": now.Add(24 * time.Hour).Unix(),
+		"typ": string(AccessToken),
+	}
+
+	tests := []struct {
+		name        string
+		modifyFn    func(jwt.MapClaims)
+		expectedErr string
+	}{
+		{
+			name: "Invalid JTI format",
+			modifyFn: func(c jwt.MapClaims) {
+				c["jti"] = "not-a-uuid"
+			},
+			expectedErr: "invalid token ID",
+		},
+		{
+			name: "Invalid SUB format",
+			modifyFn: func(c jwt.MapClaims) {
+				c["sub"] = "not-a-uuid"
+			},
+			expectedErr: "invalid user ID",
+		},
+		{
+			name: "Invalid SID format",
+			modifyFn: func(c jwt.MapClaims) {
+				c["sid"] = "not-a-uuid"
+			},
+			expectedErr: "invalid session ID",
+		},
+		{
+			name: "Missing username",
+			modifyFn: func(c jwt.MapClaims) {
+				delete(c, "usr")
+			},
+			expectedErr: "missing required claim: usr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims := make(jwt.MapClaims)
+			for k, v := range validClaims {
+				claims[k] = v
+			}
+			tt.modifyFn(claims)
+
+			err := validateTokenClaims(claims, AccessToken, []string{"iss", "aud", "nbf", "mle"})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}

--- a/gourdiantoken_verification_test.go
+++ b/gourdiantoken_verification_test.go
@@ -1,0 +1,213 @@
+// File: gourdiantoken_verification_test.go
+
+package gourdiantoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenVerificationEdgeCases(t *testing.T) {
+	config := DefaultGourdianTokenConfig(testSymmetricKey)
+	maker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+	require.NoError(t, err)
+
+	t.Run("Expired Token", func(t *testing.T) {
+		// Create token with immediate expiration
+		config := DefaultGourdianTokenConfig(testSymmetricKey)
+		config.AccessExpiryDuration = time.Nanosecond
+		tempMaker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		require.NoError(t, err)
+
+		token, err := tempMaker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"admin"}, uuid.New())
+		require.NoError(t, err)
+
+		// Wait for it to expire
+		time.Sleep(time.Millisecond)
+
+		_, err = maker.VerifyAccessToken(context.Background(), token.Token)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("Tampered Signature", func(t *testing.T) {
+		token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"admin"}, uuid.New())
+		require.NoError(t, err)
+
+		// Tamper with the token by changing one character in the signature
+		tampered := token.Token[:len(token.Token)-4] + "abcd"
+
+		_, err = maker.VerifyAccessToken(context.Background(), tampered)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signature is invalid")
+	})
+
+	t.Run("Invalid Algorithm", func(t *testing.T) {
+		// Create token with different algorithm
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+
+		claims := AccessTokenClaims{
+			ID:        uuid.New(),
+			Subject:   uuid.New(),
+			Username:  "user",
+			SessionID: uuid.New(),
+			Issuer:    config.Issuer,
+			Audience:  config.Audience,
+			Roles:     []string{"admin"},
+			IssuedAt:  time.Now(),
+			ExpiresAt: time.Now().Add(time.Hour),
+			TokenType: AccessToken,
+		}
+
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, toMapClaims(claims))
+		tokenString, err := token.SignedString(privKey)
+		require.NoError(t, err)
+
+		_, err = maker.VerifyAccessToken(context.Background(), tokenString)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unexpected signing method")
+	})
+
+	t.Run("Empty Audience", func(t *testing.T) {
+		config := DefaultGourdianTokenConfig(testSymmetricKey)
+		config.Audience = nil
+		tempMaker, err := NewGourdianTokenMaker(context.Background(), config, nil)
+		require.NoError(t, err)
+
+		token, err := tempMaker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"admin"}, uuid.New())
+		require.NoError(t, err)
+
+		// Should still verify successfully
+		_, err = tempMaker.VerifyAccessToken(context.Background(), token.Token)
+		require.NoError(t, err)
+	})
+}
+
+func TestValidateAlgorithmAndMethod(t *testing.T) {
+	tests := []struct {
+		name      string
+		algorithm string
+		method    SigningMethod
+		wantErr   bool
+	}{
+		{"Valid HS256", "HS256", Symmetric, false},
+		{"Valid RS256", "RS256", Asymmetric, false},
+		{"Invalid HS256 with Asymmetric", "HS256", Asymmetric, true},
+		{"Invalid RS256 with Symmetric", "RS256", Symmetric, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := GourdianTokenConfig{
+				Algorithm:     tt.algorithm,
+				SigningMethod: tt.method,
+			}
+			err := validateAlgorithmAndMethod(&config)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetUnixTime(t *testing.T) {
+	now := time.Now().Unix()
+	tests := []struct {
+		name  string
+		input interface{}
+		want  int64
+	}{
+		{"Float64", float64(now), now},
+		{"Int64", int64(now), now},
+		{"Int", int(now), now},
+		{"JSON Number", json.Number(fmt.Sprintf("%d", now)), now},
+		{"Invalid Type", "not a number", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getUnixTime(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	config := DefaultGourdianTokenConfig(testSymmetricKey)
+	config.RevocationEnabled = true
+	config.RotationEnabled = true
+
+	// Test NewGourdianTokenMaker with cancelled context
+	t.Run("NewGourdianTokenMaker with cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Immediately cancel the context
+
+		_, err := NewGourdianTokenMaker(ctx, config, testRedisOptions())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	})
+
+	// Test token operations with cancelled context
+	t.Run("Token operations with cancelled context", func(t *testing.T) {
+		maker, err := NewGourdianTokenMaker(context.Background(), config, testRedisOptions())
+		require.NoError(t, err)
+
+		// Test CreateAccessToken with cancelled context
+		t.Run("CreateAccessToken", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, err := maker.CreateAccessToken(ctx, uuid.New(), "user", []string{"admin"}, uuid.New())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "context canceled")
+		})
+
+		// Test CreateRefreshToken with cancelled context
+		t.Run("CreateRefreshToken", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, err := maker.CreateRefreshToken(ctx, uuid.New(), "user", uuid.New())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "context canceled")
+		})
+
+		// Test VerifyAccessToken with cancelled context (when revocation is enabled)
+		t.Run("VerifyAccessToken", func(t *testing.T) {
+			token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"admin"}, uuid.New())
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, err = maker.VerifyAccessToken(ctx, token.Token)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "context canceled")
+		})
+
+		// Test RevokeAccessToken with cancelled context
+		t.Run("RevokeAccessToken", func(t *testing.T) {
+			token, err := maker.CreateAccessToken(context.Background(), uuid.New(), "user", []string{"admin"}, uuid.New())
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			err = maker.RevokeAccessToken(ctx, token.Token)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "context canceled")
+		})
+	})
+}

--- a/tree.txt
+++ b/tree.txt
@@ -3,50 +3,26 @@
 ├── LICENSE
 ├── Makefile
 ├── Readme.md
-├── dist
-│   ├── CHANGELOG.md
-│   ├── artifacts.json
-│   ├── config.yaml
-│   └── metadata.json
+├── coverage.html
 ├── docs.go
-├── examples
-│   ├── gourdiantoken.go
-│   ├── keys
-│   │   ├── ec256_private.pem
-│   │   ├── ec256_public.pem
-│   │   ├── ed25519_private.pem
-│   │   ├── ed25519_public.pem
-│   │   ├── rsa_private.pem
-│   │   ├── rsa_pss_private.pem
-│   │   ├── rsa_pss_public.pem
-│   │   └── rsa_public.pem
-│   ├── main.go
-│   ├── scenarios
-│   │   ├── basic_usage_scenario.go
-│   │   ├── eddsa_scenario.go
-│   │   ├── high_security_scenario.go
-│   │   ├── hmac_scenario.go
-│   │   ├── multitenant_scenario.go
-│   │   ├── refresh_flow_scenario.go
-│   │   ├── revocation_scenario.go
-│   │   ├── rsa_pss_scenario.go
-│   │   ├── rsa_scenario.go
-│   │   ├── scenarios.go
-│   │   ├── short_lived_scenario.go
-│   │   ├── stateless_scenario.go
-│   │   └── token_family_scenario.go
-│   └── utils
-│       └── helpers.go
 ├── go.mod
 ├── go.sum
 ├── goReleaser.txt
 ├── gourdiantoken.go
 ├── gourdiantoken_benchmark_test.go
+├── gourdiantoken_claims_test.go
+├── gourdiantoken_concurrency_test.go
+├── gourdiantoken_config_test.go
 ├── gourdiantoken_error_test.go
+├── gourdiantoken_init_test.go
+├── gourdiantoken_integration_test.go
+├── gourdiantoken_keyparsing_test.go
+├── gourdiantoken_response_test.go
 ├── gourdiantoken_serialization_test.go
 ├── gourdiantoken_test.go
-├── tests_helpers.go
+├── gourdiantoken_validation_test.go
+├── gourdiantoken_verification_test.go
 ├── tree.txt
 └── version.go
 
-6 directories, 44 files
+1 directory, 25 files

--- a/version.go
+++ b/version.go
@@ -1,3 +1,5 @@
+// File: version.go
+
 package gourdiantoken
 
-var Version = "v1.0.1"
+var Version = "v1.0.3"


### PR DESCRIPTION
* new payload structure

* removed comments

* config structure changes

* updated constructor functions

* improved crewtae tokens

* validateTokenClaims improved

* more security hardened

* used constants

* final

* ok      github.com/gourdian25/gourdiantoken     0.006s  coverage: 16.5% of statements

* ok      github.com/gourdian25/gourdiantoken     5.391s  coverage: 44.6% of statements

* transformed tests

* 60.6% of statements

* 61.3% of statements

* goood benching

* 61 still

* more tests

* more tests

* coverage: 65.2% of statements

* 65.3% of statements

* coverage: 65.7% of statements

* coverage: 66.0% of statements

* coverage: 66.0% of statements

* coverage: 68.8% of statements

* 69

* hehe

* coverage: 69.8% of statements

* coverage: 70.3% of statements

* introduced comments

* tt

* done